### PR TITLE
[worklist#12] Vision Overhaul Phase A engine runner

### DIFF
--- a/docs/vision-exercise-specs.md
+++ b/docs/vision-exercise-specs.md
@@ -1,0 +1,508 @@
+# Vision Exercise Specs
+
+Source corpus: `screenfit/`
+
+Extraction pass:
+
+- `Vision Foundations Workbook - Interactive.pdf`: 29 pages, 19,441 extracted characters. This is the primary extractable source for weekly structure, assessments, setup, and the 30-workout sequence.
+- `Week One` through `Week Six Interactive Checklist.pdf`: extractable and used to confirm workout order, pairing, reminders, progress checks, and weekly takeaways.
+- `Set-up Interactive Checklist.pdf`: extractable and used for setup requirements.
+- Individual `Exercise-*` sheets: title text extracted for most files, but detailed body content was not extractable through `pdfplumber`; these appear to be image-first sheets. Their extraction limitation is logged here rather than guessed as quoted source.
+- `Lesson-*` sheets: most returned zero or near-zero body text, except title/letter-chart fragments. Logged as extraction-limited.
+- `Improve eyesight at various distances.md`: used as the existing product brief for progressive distance, Snellen, device-distance, and session tracking requirements.
+
+Program structure extracted from the workbook/checklists:
+
+- Six-week course.
+- Five workouts per week.
+- Each day repeats the previous exercise and adds the new exercise.
+- Baselines and review checkpoints appear at setup, halfway, and post-program.
+- Checklists emphasize daily notes, challenges, breakthroughs, eye-jump results, and moving-object timing.
+
+Device rules for all engines:
+
+- Phone distance: arm length, roughly 20-60 cm.
+- Desktop distance: desk distance, roughly 60-100 cm.
+- No engine should instruct users to stand meters away from controls.
+- Visual stimuli are functional training targets, not decoration.
+- Static instruction cards with a timer and a completion button are not acceptable engines.
+
+## 1. Pushups For Your Focusing System
+
+Source: `Exercise-01-Pushups-for-Focusing.pdf`, Week One checklist, workbook.
+
+Purpose: Build accommodation and convergence control by repeatedly moving a near target through the edge of clarity.
+
+Protocol: Present a high-contrast near target. User starts at a comfortable distance, brings the target closer in small steps, pauses at first blur, breathes, and regains clarity before continuing.
+
+Timing/reps: Week One workouts 1-2. App default: 2-3 rounds of 60-90 seconds.
+
+Progression: Small distance changes, roughly 0.5-2 cm. Advance only when clarity returns without strain.
+
+Physical eye action: Both eyes converge and accommodate while head and shoulders stay quiet.
+
+Engine must render/measure: Render a sharp target at calibrated size, prompt closer/farther micro-adjustments, track distance band, blur-recovery self-report, completed rounds, and session duration.
+
+## 2. Eye Stretches
+
+Source: `Exercise-02-Eye-Stretches.pdf`, Week One checklist.
+
+Purpose: Restore comfortable ocular range before harder focus and pursuit drills.
+
+Protocol: Guide slow gaze holds to left, right, up, down, and diagonals while the head remains still.
+
+Timing/reps: Week One workouts 2-3. App default: 8 directions, 5-8 seconds each, 2 rounds.
+
+Progression: Increase hold time and add diagonal directions only if movement stays pain-free.
+
+Physical eye action: Extraocular muscles move the eyes to range without neck substitution.
+
+Engine must render/measure: Render directional targets at screen edges, measure hold completion, missed holds, head-stillness self-checks, and discomfort flag.
+
+## 3. Smooth Tracking
+
+Source: `Exercise-03-Smooth-Tracking.pdf`, Week One checklist.
+
+Purpose: Train smooth pursuit so the eyes glide instead of jumping.
+
+Protocol: User follows a moving target with eyes only through horizontal, vertical, circular, and figure-8 paths.
+
+Timing/reps: Week One workouts 3-4. App default: 3 minutes across four path phases.
+
+Progression: Start slower and larger. Increase speed and path complexity only when the target stays clear and head remains still.
+
+Physical eye action: Smooth pursuit with quiet cervical spine and relaxed jaw.
+
+Engine must render/measure: Render an animated pursuit target, current path, speed phase, phase timing, loops completed, pauses, reduced-motion fallback, and subjective smoothness checks.
+
+## 4. Palming
+
+Source: `Exercise-04-Palming.pdf`, Week One checklist.
+
+Purpose: Downshift visual tension and nervous-system load.
+
+Protocol: User warms palms, cups them over closed eyes without pressure, breathes slowly, and notices the visual field darkening.
+
+Timing/reps: Week One workouts 4-5. App default: 3-4 minutes.
+
+Progression: Increase breath steadiness and reduce facial tension before harder drills.
+
+Physical eye action: Eyes closed, orbital area relaxed, no pressure on the eyeballs.
+
+Engine must render/measure: Render a breathing orb or dark-field cue, time inhale/exhale phases, record tension checks, and capture whether the user felt visual relaxation.
+
+## 5. Focus Trombone
+
+Source: `Lesson -5 - Focus Trombone (2).pdf`, Week One/Two checklists.
+
+Purpose: Train dynamic near/far accommodation toggling.
+
+Protocol: User alternates focus between a near and farther target in rhythm with breath.
+
+Timing/reps: Week One workout 5 and Week Two workout 6. App default: 2-4 minutes.
+
+Progression: Increase distance spread gradually. Add smaller text only after clarity is reliable.
+
+Physical eye action: Accommodation and vergence shift between depth planes.
+
+Engine must render/measure: Render near/far targets or screen-size equivalents, guide toggles, record clear/blur responses, target distance, and successful switches.
+
+## 6. Eye Jumps
+
+Source: `Exercise-06-Eye-Jumps.pdf`, `Lesson -6 - Eye Jumps (1).pdf`, Week Two checklist.
+
+Purpose: Train accurate saccades and reading/sport quickness.
+
+Protocol: User jumps gaze between two or more targets on cue, identifying the active target without head movement.
+
+Timing/reps: Week Two workouts 6-7. App default: 60 seconds per target layout.
+
+Progression: Increase tempo after accuracy is high; add diagonals and more targets.
+
+Physical eye action: Fast saccades with fixation landing on the target.
+
+Engine must render/measure: Render target pairs/quadrants, cue cadence, hit/miss responses, reaction time, accuracy, and max controlled tempo.
+
+## 7. Expanding Your Side Vision
+
+Source: `Exercise-07-Expanding-Side-Vision.pdf`, `Lesson -7 - Expanding your Side Vision (1).pdf`, Week Two checklist.
+
+Purpose: Reduce tunnel vision by improving peripheral awareness.
+
+Protocol: User fixes gaze centrally while detecting peripheral flashes, colors, or shapes.
+
+Timing/reps: Week Two workouts 7-8. App default: 2-3 rounds of 60 seconds.
+
+Progression: Move targets farther outward, reduce contrast, or increase stimulus count.
+
+Physical eye action: Central fixation with peripheral attention expansion.
+
+Engine must render/measure: Render center fixation plus peripheral stimuli, measure detection accuracy by quadrant, fixation breaks, and field-width level.
+
+## 8. Two-Eyed Coordination
+
+Source: `Exercise-08-Two-Eyed-Coordination.pdf`, Week Two checklist.
+
+Purpose: Improve binocular teaming and depth coordination.
+
+Protocol: User performs paired-eye tasks that require both eyes to maintain a shared target.
+
+Timing/reps: Week Two workouts 8-9. App default: 2-3 minutes.
+
+Progression: Increase target separation or add binocular modes after stable fusion.
+
+Physical eye action: Both eyes converge/diverge together without suppression or strain.
+
+Engine must render/measure: Render paired targets, optional red/green or duplicate layouts, record fusion self-report, break events, and successful holds.
+
+## 9. Peripheral Pointing
+
+Source: `Exercise-09-Peripheral-Pointing.pdf`, `Lesson -9 - Peripheral Pointing (1).pdf`, Week Two checklist.
+
+Purpose: Connect peripheral vision to body mapping and pointing accuracy.
+
+Protocol: User keeps central gaze fixed, detects a peripheral target, and points toward it without looking directly.
+
+Timing/reps: Week Two workouts 9-10. App default: 20-30 targets.
+
+Progression: Add category rules, smaller targets, and wider positions.
+
+Physical eye action: Fixation stays central while arm reaches to peripheral location.
+
+Engine must render/measure: Render peripheral targets, capture tap/point direction, quadrant accuracy, reaction time, and fixation-quality self-check.
+
+## 10. Taking In Space
+
+Source: `Exercise-10-Taking-in-Space.pdf`, Week Two/Three checklists.
+
+Purpose: Build whole-field spatial awareness in daily movement.
+
+Protocol: User softens gaze and notices the room edges or walking environment while keeping attention broad.
+
+Timing/reps: Week Two workout 10 and Week Three workout 11. App default: 2 minutes.
+
+Progression: Add walking or object-count tasks once seated awareness is easy.
+
+Physical eye action: Soft central fixation with broad peripheral attention.
+
+Engine must render/measure: Render expanding field cues, prompt object counts by zone, record peripheral count, confidence, and balance/tension checks.
+
+## 11. Mirror Eye Movement
+
+Source: `Exercise-11-Mirror-Eye-Movement.pdf`, Week Three checklist.
+
+Purpose: Train eye movement while a mirror or app feedback keeps head movement honest.
+
+Protocol: User tracks prescribed paths while monitoring that head and shoulders stay centered.
+
+Timing/reps: Week Three workouts 11-12. App default: 3 minutes.
+
+Progression: Add diagonal paths and smaller targets.
+
+Physical eye action: Eyes scan while head remains fixed.
+
+Engine must render/measure: Render path targets, mirror/head-stillness prompts, path completion, direction changes, and self-reported head drift.
+
+## 12. Alphabet Visualization
+
+Source: `Exercise-12-Alphabet-Visualization.pdf`, Week Three checklist.
+
+Purpose: Strengthen visual memory and eye-brain imagery.
+
+Protocol: User visualizes letters or traces an alphabet path with eyes closed or soft gaze.
+
+Timing/reps: Week Three workouts 12-13. App default: one alphabet pass or 2 minutes.
+
+Progression: Move from large letters to smaller letters, reverse order, or randomized letters.
+
+Physical eye action: Internal visual tracking and memory recall.
+
+Engine must render/measure: Render letter prompts, ask for imagined direction/path, record completion, recall accuracy, and mental clarity score.
+
+## 13. Eye Squeezes
+
+Source: `Exercise-13-Eye-Squeezes.pdf`, Week Three checklist.
+
+Purpose: Reset blink quality and release ocular tension.
+
+Protocol: User gently closes/squeezes eyes, releases fully, and blinks naturally.
+
+Timing/reps: Week Three workouts 13-14. Checklist notes this can be done daily with water breaks.
+
+Progression: Improve relaxation after each release; do not increase force.
+
+Physical eye action: Controlled eyelid closure and release, not eyeball pressure.
+
+Engine must render/measure: Render squeeze/release rhythm, count reps, record dryness/tension before and after, and discomfort flag.
+
+## 14. Pendrops
+
+Source: `Exercise-14-Pendrops.pdf`, Week Three checklist.
+
+Purpose: Train vertical tracking, anticipation, and fixation recovery.
+
+Protocol: User follows or catches falling visual targets while maintaining posture.
+
+Timing/reps: Week Three workouts 14-15. App default: 20-40 drops.
+
+Progression: Increase drop speed, reduce target size, or add distractors.
+
+Physical eye action: Vertical pursuit with fixation landing.
+
+Engine must render/measure: Render falling targets, capture tap/response accuracy, reaction time, misses, and level speed.
+
+## 15. Laterality
+
+Source: `Exercise-15-Laterality.pdf`, `Lesson -15 laterallity.pdf`, Week Three/Four checklists.
+
+Purpose: Improve left/right mapping and cross-body coordination.
+
+Protocol: User responds to left/right visual prompts with matching or opposite hand/body actions.
+
+Timing/reps: Week Three workout 15 and Week Four workout 16. App default: 30-60 prompts.
+
+Progression: Add crossed responses, faster cadence, and mixed up/down prompts.
+
+Physical eye action: Visual target recognition plus body-side mapping.
+
+Engine must render/measure: Render left/right prompts, capture response side, reaction time, accuracy, and crossed-midline errors.
+
+## 16. Smooth Pursuits
+
+Source: `Exercise-16-Smooth-Pursuits.pdf`, Week Four checklist.
+
+Purpose: Advance Smooth Tracking into longer or more complex pursuit control.
+
+Protocol: User follows moving stimuli through longer, multi-axis pursuit paths.
+
+Timing/reps: Week Four workouts 16-17. App default: 3-5 minutes.
+
+Progression: Increase path speed, add corners/curves, and reduce target size.
+
+Physical eye action: Continuous pursuit without saccadic jumping.
+
+Engine must render/measure: Render multi-path motion, speed phase, loop count, pauses, subjective jerkiness, and head-stillness checks.
+
+## 17. Close Eye Movements
+
+Source: `Exercise-17-Close-Eye-Movements.pdf`, Week Four checklist.
+
+Purpose: Train controlled ocular movement at close range.
+
+Protocol: User tracks near targets or performs small controlled gaze shifts at arm length.
+
+Timing/reps: Week Four workouts 17-18. App default: 2-3 minutes.
+
+Progression: Shrink target path and add closer ranges only if comfortable.
+
+Physical eye action: Small range movements with accommodation loaded.
+
+Engine must render/measure: Render close-range targets, distance guidance, blur reports, path completion, and discomfort flag.
+
+## 18. Eye Rolls
+
+Source: `Exercise-18 Eye Rolls.pdf`, Week Four checklist.
+
+Purpose: Maintain comfortable circular range and reduce stiffness.
+
+Protocol: User rolls gaze slowly clockwise and counterclockwise without neck motion.
+
+Timing/reps: Week Four workouts 18-19. App default: 3 rounds each direction.
+
+Progression: Increase smoothness, not speed.
+
+Physical eye action: Circular extraocular movement.
+
+Engine must render/measure: Render circular path, count completed circles, direction changes, smoothness self-check, and strain flag.
+
+## 19. Strengthening Your Focus
+
+Source: `Exercise -19 Strengthening Your Focus.pdf`, Week Four checklist.
+
+Purpose: Reinforce accommodation endurance after earlier focus drills.
+
+Protocol: User sustains clarity on a target near the edge of blur, then recovers.
+
+Timing/reps: Week Four workouts 19-20. App default: 3 holds of 30-45 seconds.
+
+Progression: Increase hold time or decrease target size after stable clarity.
+
+Physical eye action: Sustained accommodation without facial/neck tension.
+
+Engine must render/measure: Render high-contrast target, hold timer, clarity check-ins, blur recovery time, and max hold.
+
+## 20. Eye Massages
+
+Source: `Exercise-20 Eye Massages.pdf`, Week Four/Five checklists.
+
+Purpose: Provide a toolkit exercise for tension management and recovery.
+
+Protocol: User performs gentle surrounding-area massage without direct pressure on the eyeball.
+
+Timing/reps: Week Four workout 20 and Week Five workout 21. App default: 2 minutes.
+
+Progression: Improve relaxation quality; never increase pressure.
+
+Physical eye action: Eyes relaxed or closed while surrounding tissue relaxes.
+
+Engine must render/measure: Render safe-zone map, guide sequence, record completion, pressure caution confirmations, and before/after tension score.
+
+## 21. Focused Eye Tracking
+
+Source: `Exercise -21 Focused Eye Tracking.pdf`, `Lesson -21 - Focused Eye Tracking (1).pdf`, Week Five checklist.
+
+Purpose: Combine focus stability with tracking movement.
+
+Protocol: User keeps the moving target sharp while tracking a prescribed route.
+
+Timing/reps: Week Five workouts 21-22. App default: 3 minutes.
+
+Progression: Add speed only after the target stays clear through the full path.
+
+Physical eye action: Pursuit plus accommodation stability.
+
+Engine must render/measure: Render moving target with sharpness challenge, path phase, blur taps, loops completed, and recovery time.
+
+## 22. Large Eye Jumps
+
+Source: `Exercise -22 Large Eye Jumps.pdf`, `Lesson -22 - Large Eye Jumps (3).pdf`, Week Five checklist.
+
+Purpose: Expand saccadic range with larger jumps.
+
+Protocol: User jumps gaze between widely spaced targets and identifies each one.
+
+Timing/reps: Week Five workouts 22-23. App default: 30-50 jumps.
+
+Progression: Increase separation, tempo, and number of target positions.
+
+Physical eye action: Large saccades with accurate fixation landing.
+
+Engine must render/measure: Render large separated targets, capture correct identification, reaction time, misses, and max separation.
+
+## 23. Training Your Side Vision
+
+Source: `Exercise -23 Training Your Side Vision.pdf`, `Lesson -23 - Training Your Side Vision (1).pdf`, Week Five checklist.
+
+Purpose: Advance side-vision detection and attention.
+
+Protocol: User maintains center fixation and detects side targets under changing contrast or position.
+
+Timing/reps: Week Five workouts 23-24. App default: 2-3 rounds of 60 seconds.
+
+Progression: Lower contrast, increase eccentricity, or add simultaneous targets.
+
+Physical eye action: Fixation plus lateral peripheral awareness.
+
+Engine must render/measure: Render side targets, measure left/right detection accuracy, response time, and fixation-break self-check.
+
+## 24. Mirror Eye Movement Part Two
+
+Source: `Exercise -24 Mirror Eye Movement, Part 2.pdf`, Week Five checklist.
+
+Purpose: Upgrade mirror eye movement with more complex paths.
+
+Protocol: User performs mirror-assisted eye movements with added diagonals, reversals, or dual tasks.
+
+Timing/reps: Week Five workouts 24-25. App default: 3-4 minutes.
+
+Progression: Add path complexity and require cleaner head stillness.
+
+Physical eye action: Eyes sweep through prescribed paths while posture stays stable.
+
+Engine must render/measure: Render advanced paths, count reversals, ask head-drift checks, and record completed path sets.
+
+## 25. Visual Scan
+
+Source: `Exercise -25 Visual Scan.pdf`, `Lesson -25 - Visual Scan (3).pdf`, Week Five/Six checklists.
+
+Purpose: Improve systematic scanning for reading, desk work, and space navigation.
+
+Protocol: User scans rows, columns, or a visual field in a specific order and identifies targets.
+
+Timing/reps: Week Five workout 25 and Week Six workout 26. App default: 2-4 scan grids.
+
+Progression: Increase grid size, reduce contrast, add distractors, and time the scan.
+
+Physical eye action: Ordered saccades and fixation along a scan pattern.
+
+Engine must render/measure: Render scan grid, capture targets found, omissions, scan time, and revisit count.
+
+## 26. Figure 8 Fixation
+
+Source: `Exercise -26 Figure 8 Fixation (1).pdf`, Week Six checklist.
+
+Purpose: Integrate fixation and pursuit on an infinity path.
+
+Protocol: User follows or fixates along a figure-8 path while breathing steadily.
+
+Timing/reps: Week Six workouts 26-27. App default: 2 directions, 60-90 seconds each.
+
+Progression: Change size, speed, direction, or add near/far layers.
+
+Physical eye action: Smooth pursuit around crossing loops with central reorientation.
+
+Engine must render/measure: Render infinity path, direction, speed, completed loops, midline drift self-check, and blur events.
+
+## 27. Pyramid Pointing
+
+Source: `Exercise -27 Pyramid Pointing (1).pdf`, `Lesson -27 - Pyramid Pointing (2).pdf`, Week Six checklist.
+
+Purpose: Combine pointing, spatial mapping, and progressively organized visual targets.
+
+Protocol: User points or taps targets arranged in a pyramid sequence while preserving gaze control.
+
+Timing/reps: Week Six workouts 27-28. App default: 3 pyramid passes.
+
+Progression: Increase pyramid size, randomize order, or add left/right hand rules.
+
+Physical eye action: Visual search, saccades, and hand-eye coordination.
+
+Engine must render/measure: Render pyramid targets, capture tap order, timing, accuracy, and hand-side prompts.
+
+## 28. Developing Your Internal GPS
+
+Source: `Exercise -28 Developing Your Internal GPS.pdf`, Week Six checklist.
+
+Purpose: Strengthen spatial orientation and internal mapping.
+
+Protocol: User tracks positions, directions, or routes and recalls where targets appeared.
+
+Timing/reps: Week Six workouts 28-29. App default: 2-3 memory routes.
+
+Progression: Add more waypoints, delay recall, or rotate the map.
+
+Physical eye action: Visual mapping plus memory and direction recall.
+
+Engine must render/measure: Render waypoints, hide/reveal map, record recall accuracy, route completion, and confidence.
+
+## 29. Focusing Flexibility
+
+Source: `Exercise -29 Focusing Flexibility.pdf`, Week Six checklist.
+
+Purpose: Improve flexible switching across focus distances.
+
+Protocol: User alternates between targets at different sizes or depths and reports clarity.
+
+Timing/reps: Week Six workouts 29-30. App default: 3 rounds of near/mid/far equivalents.
+
+Progression: Add smaller text, faster switching, or wider distance range.
+
+Physical eye action: Accommodation changes quickly without strain.
+
+Engine must render/measure: Render multiple target depths, guide switching, measure clear responses, switch accuracy, and blur recovery time.
+
+## 30. Following A Moving Object
+
+Source: `Exercise -30 Following a Moving Object.pdf`, `Lesson -30 - Following a Moving Object (1).pdf`, Week Six checklist.
+
+Purpose: Integrate pursuit with real-world moving targets and endurance.
+
+Protocol: User follows a moving object, then records timing or reading comparison as noted in the Week Six checklist.
+
+Timing/reps: Week Six workout 30. App default: 3 moving-object rounds plus result capture.
+
+Progression: Increase movement speed, add unpredictable direction changes, and compare paragraph timing.
+
+Physical eye action: Smooth pursuit, fixation recovery, and sustained attention.
+
+Engine must render/measure: Render moving object paths, capture pursuit rounds, misses, speed level, and paragraph timing fields.

--- a/src/components/Vision/Engines/GuidedStimulusEngine.tsx
+++ b/src/components/Vision/Engines/GuidedStimulusEngine.tsx
@@ -1,0 +1,246 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { CheckCircle, Eye, Hand, MoveHorizontal, Sparkles, Zap } from 'lucide-react'
+import type { ExerciseEngineDefinition, ExerciseEngineProps } from './types'
+import type { VisionExercise } from '@/data/visionExercises'
+
+const DEFAULT_DURATION_SECONDS = 120
+
+export function createGuidedStimulusEngine(exercise: VisionExercise): ExerciseEngineDefinition {
+  return {
+    id: `${exercise.id}-guided-stimulus-v1`,
+    label: `${exercise.title} guided stimulus`,
+    sourceExerciseId: exercise.id,
+    supportedDeviceModes: ['phone', 'desktop'],
+    measurable: false,
+    defaultDurationSeconds: DEFAULT_DURATION_SECONDS,
+    component: GuidedStimulusEngine,
+  }
+}
+
+export default function GuidedStimulusEngine({
+  exercise,
+  difficulty,
+  deviceMode,
+  reducedMotion,
+  controls,
+}: ExerciseEngineProps) {
+  const [stimulusStep, setStimulusStep] = useState(0)
+  const [qualityChecks, setQualityChecks] = useState<Record<string, boolean>>({})
+  const cues = useMemo(() => buildCues(exercise), [exercise])
+  const motion = getMotionForExercise(exercise)
+  const stimulusSize = deviceMode === 'phone' ? 34 : 42
+
+  useEffect(() => {
+    if (controls.phase !== 'active' || controls.isPaused) return
+    const timer = window.setInterval(() => {
+      setStimulusStep((step) => step + 1)
+    }, reducedMotion ? 2600 : motion.intervalMs[difficulty])
+    return () => window.clearInterval(timer)
+  }, [controls.phase, controls.isPaused, difficulty, motion.intervalMs, reducedMotion])
+
+  const activeCue = cues[stimulusStep % cues.length]
+  const position = getStimulusPosition(motion.kind, stimulusStep, reducedMotion)
+
+  const complete = () => {
+    controls.complete({
+      completionMode: 'subjective',
+      metrics: {
+        stimulusPattern: motion.kind,
+        cueCount: cues.length,
+        qualityChecksPassed: Object.values(qualityChecks).filter(Boolean).length,
+        reducedMotion,
+      },
+    })
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="bg-gradient-to-br from-gray-800/80 to-gray-900/80 backdrop-blur-sm rounded-xl p-5 border border-primary-400/20 shadow-lg">
+        <div className="flex items-start gap-4">
+          <div className="p-3 rounded-xl bg-primary-600/20">
+            <motion.icon className="w-7 h-7 text-primary-300" />
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wider text-primary-300 font-semibold">
+              Scaffold engine
+            </div>
+            <h3 className="text-2xl font-bold text-white">{exercise.title}</h3>
+            <p className="text-gray-300 mt-2">{exercise.summary}</p>
+          </div>
+        </div>
+      </div>
+
+      <div
+        className="relative overflow-hidden rounded-xl border border-primary-400/20 bg-gray-950 shadow-2xl"
+        style={{ minHeight: deviceMode === 'phone' ? 340 : 420 }}
+      >
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(63,191,181,0.18),transparent_62%)]" />
+        <div className="absolute inset-8 rounded-full border border-primary-400/10" />
+        <div className="absolute left-8 right-8 top-1/2 h-px bg-primary-400/10" />
+        <div className="absolute top-8 bottom-8 left-1/2 w-px bg-primary-400/10" />
+
+        {motion.kind === 'breath' && (
+          <div
+            className="absolute rounded-full border border-secondary-300/30 bg-secondary-400/15 transition-all duration-1000"
+            style={{
+              left: '50%',
+              top: '50%',
+              width: stimulusStep % 2 === 0 ? 170 : 230,
+              height: stimulusStep % 2 === 0 ? 170 : 230,
+              transform: 'translate(-50%, -50%)',
+              boxShadow: '0 0 80px rgba(114, 194, 71, 0.18)',
+            }}
+          />
+        )}
+
+        <div
+          className="absolute rounded-full transition-all duration-500"
+          style={{
+            left: `${position.x}%`,
+            top: `${position.y}%`,
+            width: stimulusSize,
+            height: stimulusSize,
+            transform: 'translate(-50%, -50%)',
+            background: motion.color,
+            boxShadow: '0 0 34px rgba(63, 191, 181, 0.45)',
+          }}
+        />
+
+        {motion.kind === 'peripheral' && Array.from({ length: 10 }).map((_, index) => {
+          const angle = (Math.PI * 2 * index) / 10
+          const x = 50 + Math.cos(angle) * 34
+          const y = 50 + Math.sin(angle) * 26
+          return (
+            <div
+              key={index}
+              className={`absolute h-3 w-3 rounded-full transition-opacity duration-300 ${
+                index === stimulusStep % 10 ? 'opacity-100 bg-secondary-300' : 'opacity-25 bg-primary-300'
+              }`}
+              style={{ left: `${x}%`, top: `${y}%` }}
+            />
+          )
+        })}
+
+        <div className="absolute left-4 right-4 top-4 rounded-xl border border-primary-400/20 bg-gray-950/75 p-4 backdrop-blur-sm">
+          <div className="text-xs uppercase tracking-wider text-primary-300 font-semibold">Live cue</div>
+          <div className="text-white mt-1">{activeCue}</div>
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        {buildQualityChecks(exercise).map((check) => (
+          <button
+            key={check}
+            onClick={() => setQualityChecks((current) => ({ ...current, [check]: !current[check] }))}
+            className={`rounded-lg border px-4 py-3 text-left transition-all ${
+              qualityChecks[check]
+                ? 'border-secondary-400/50 bg-secondary-500/15 text-secondary-100'
+                : 'border-gray-700/50 bg-gray-900/60 text-gray-300 hover:border-primary-400/40'
+            }`}
+          >
+            <div className="flex items-start gap-2 text-sm font-semibold">
+              <CheckCircle className="w-4 h-4 mt-0.5" />
+              {check}
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <div className="flex justify-center">
+        <button
+          onClick={complete}
+          className="px-6 py-3 rounded-lg bg-gradient-to-r from-secondary-500 to-primary-500 hover:from-secondary-600 hover:to-primary-600 text-white font-bold flex items-center gap-2 transition-all shadow-lg shadow-primary-500/20"
+        >
+          <CheckCircle className="w-5 h-5" />
+          Capture Result
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function buildCues(exercise: VisionExercise) {
+  const checkpoints = exercise.checkpoints.length > 0 ? exercise.checkpoints : [exercise.summary]
+  const guidance = exercise.guidance.map((item) => item.detail)
+  return [...checkpoints, ...guidance].slice(0, 6)
+}
+
+function buildQualityChecks(exercise: VisionExercise) {
+  if (exercise.category === 'downshift') {
+    return ['Jaw and brow relaxed', 'Breath stayed slow', 'No eye pressure']
+  }
+  if (exercise.category === 'peripheral') {
+    return ['Center gaze stayed anchored', 'Edges stayed visible', 'Head stayed quiet']
+  }
+  if (exercise.category === 'speed') {
+    return ['Eyes moved before head', 'Targets stayed clear', 'Tempo stayed controlled']
+  }
+  if (exercise.category === 'integration') {
+    return ['Left/right calls were accurate', 'Body stayed balanced', 'Breath stayed nasal']
+  }
+  return ['Movement stayed smooth', 'Blur recovered quickly', 'Neck stayed relaxed']
+}
+
+function getMotionForExercise(exercise: VisionExercise) {
+  if (exercise.category === 'downshift') {
+    return {
+      kind: 'breath' as const,
+      icon: Sparkles,
+      color: 'radial-gradient(circle at 35% 35%, #ffffff 0 8%, #72C247 10% 100%)',
+      intervalMs: { starter: 5000, standard: 4300, challenge: 3800, advanced: 3400 },
+    }
+  }
+  if (exercise.category === 'peripheral') {
+    return {
+      kind: 'peripheral' as const,
+      icon: Eye,
+      color: 'radial-gradient(circle at 35% 35%, #ffffff 0 8%, #3FBFB5 10% 100%)',
+      intervalMs: { starter: 2400, standard: 2000, challenge: 1700, advanced: 1400 },
+    }
+  }
+  if (exercise.category === 'speed') {
+    return {
+      kind: 'saccade' as const,
+      icon: Zap,
+      color: 'radial-gradient(circle at 35% 35%, #ffffff 0 8%, #facc15 10% 100%)',
+      intervalMs: { starter: 1800, standard: 1400, challenge: 1100, advanced: 850 },
+    }
+  }
+  if (exercise.category === 'integration') {
+    return {
+      kind: 'integration' as const,
+      icon: Hand,
+      color: 'radial-gradient(circle at 35% 35%, #ffffff 0 8%, #a78bfa 10% 100%)',
+      intervalMs: { starter: 2500, standard: 2100, challenge: 1800, advanced: 1500 },
+    }
+  }
+  return {
+    kind: 'tracking' as const,
+    icon: MoveHorizontal,
+    color: 'radial-gradient(circle at 35% 35%, #ffffff 0 8%, #3FBFB5 10% 100%)',
+    intervalMs: { starter: 3200, standard: 2700, challenge: 2300, advanced: 1900 },
+  }
+}
+
+function getStimulusPosition(kind: ReturnType<typeof getMotionForExercise>['kind'], step: number, reducedMotion: boolean) {
+  const slowStep = reducedMotion ? Math.floor(step / 2) : step
+  const t = slowStep % 8
+  const positions = [
+    { x: 28, y: 50 },
+    { x: 38, y: 35 },
+    { x: 50, y: 28 },
+    { x: 62, y: 35 },
+    { x: 72, y: 50 },
+    { x: 62, y: 65 },
+    { x: 50, y: 72 },
+    { x: 38, y: 65 },
+  ]
+
+  if (kind === 'breath') return { x: 50, y: 50 }
+  if (kind === 'saccade') return positions[(step * 3) % positions.length]
+  if (kind === 'peripheral') return { x: 50, y: 50 }
+  if (kind === 'integration') return positions[(step * 2 + 1) % positions.length]
+  return positions[t]
+}

--- a/src/components/Vision/Engines/SessionRunner.tsx
+++ b/src/components/Vision/Engines/SessionRunner.tsx
@@ -1,0 +1,372 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { ArrowRight, CheckCircle, Clock, Pause, Play, RotateCcw, Trophy, Volume2, VolumeX } from 'lucide-react'
+import type {
+  ExerciseEngineDefinition,
+  ExerciseEngineResult,
+  ExerciseLifecyclePhase,
+  SessionRunnerResult,
+  SessionRunnerSaveContext,
+} from './types'
+import type { VisionExercise } from '@/data/visionExercises'
+
+interface SessionRunnerItem {
+  exercise: VisionExercise
+  engine: ExerciseEngineDefinition
+}
+
+interface SessionRunnerProps {
+  items: SessionRunnerItem[]
+  deviceMode?: 'phone' | 'desktop'
+  difficulty?: 'starter' | 'standard' | 'challenge' | 'advanced'
+  reducedMotion?: boolean
+  saveContext?: SessionRunnerSaveContext
+  onComplete?: (result: SessionRunnerResult) => void
+  onBack?: () => void
+}
+
+export default function SessionRunner({
+  items,
+  deviceMode = 'phone',
+  difficulty = 'standard',
+  reducedMotion = false,
+  saveContext,
+  onComplete,
+  onBack,
+}: SessionRunnerProps) {
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [phase, setPhase] = useState<ExerciseLifecyclePhase>(() => getInitialPhase(items[0]?.engine))
+  const [isPaused, setIsPaused] = useState(false)
+  const [elapsedSeconds, setElapsedSeconds] = useState(0)
+  const [activeSeconds, setActiveSeconds] = useState(0)
+  const [results, setResults] = useState<ExerciseEngineResult[]>([])
+  const [sessionElapsed, setSessionElapsed] = useState(0)
+  const [muted, setMuted] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+  const sessionTimerRef = useRef<NodeJS.Timeout | null>(null)
+
+  const currentItem = items[currentIndex]
+  const currentDuration = currentItem?.engine.defaultDurationSeconds || 180
+  const remainingSeconds = Math.max(0, currentDuration - elapsedSeconds)
+  const progress = currentDuration > 0 ? Math.min(100, (elapsedSeconds / currentDuration) * 100) : 0
+  const EngineComponent = currentItem?.engine.component
+  const displayOptions = currentItem?.engine.displayOptions || {}
+
+  const completedIds = useMemo(() => results.map((result) => result.exerciseId), [results])
+
+  useEffect(() => {
+    sessionTimerRef.current = setInterval(() => {
+      setSessionElapsed((value) => value + 1)
+    }, 1000)
+
+    return () => {
+      if (sessionTimerRef.current) clearInterval(sessionTimerRef.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (phase !== 'active' || isPaused) return
+
+    const timer = setInterval(() => {
+      setElapsedSeconds((value) => {
+        const next = value + 1
+        if (next >= currentDuration) {
+          window.setTimeout(() => completeCurrent(), 0)
+        }
+        return next
+      })
+      setActiveSeconds((value) => value + 1)
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [phase, isPaused, currentDuration])
+
+  useEffect(() => {
+    if (muted || typeof window === 'undefined' || !currentItem) return
+    if (!('speechSynthesis' in window)) return
+
+    const text = phase === 'intro'
+      ? `Prepare for ${currentItem.exercise.title}.`
+      : phase === 'active'
+        ? `Begin ${currentItem.exercise.title}.`
+        : phase === 'cooldown'
+          ? 'Cooldown. Blink and soften your gaze.'
+          : `${currentItem.exercise.title} complete.`
+
+    window.speechSynthesis.cancel()
+    const utterance = new SpeechSynthesisUtterance(text)
+    utterance.rate = 0.92
+    utterance.volume = 0.75
+    window.speechSynthesis.speak(utterance)
+  }, [phase, currentItem, muted])
+
+  if (!currentItem || !EngineComponent) {
+    return (
+      <div className="bg-gradient-to-br from-gray-800/80 to-gray-900/80 backdrop-blur-sm rounded-xl p-8 border border-primary-400/20 text-center">
+        <Trophy className="w-14 h-14 text-secondary-400 mx-auto mb-4" />
+        <h3 className="text-2xl font-bold text-white mb-2">Session Complete</h3>
+        <p className="text-gray-300 mb-6">All available engines in this session are finished.</p>
+        {saveError && <p className="text-red-300 text-sm mb-4">{saveError}</p>}
+        {onBack && (
+          <button
+            onClick={onBack}
+            className="px-6 py-3 rounded-lg bg-primary-600 hover:bg-primary-700 text-white font-semibold"
+          >
+            Back to session
+          </button>
+        )}
+      </div>
+    )
+  }
+
+  const controls = {
+    phase,
+    isPaused,
+    elapsedSeconds,
+    remainingSeconds,
+    progress,
+    pause: () => setIsPaused(true),
+    resume: () => setIsPaused(false),
+    restart: restartCurrent,
+    complete: completeCurrent,
+  }
+
+  function startCurrent() {
+    setPhase('active')
+    setIsPaused(false)
+  }
+
+  function restartCurrent() {
+    setElapsedSeconds(0)
+    setActiveSeconds(0)
+    setPhase(getInitialPhase(currentItem?.engine))
+    setIsPaused(false)
+  }
+
+  async function completeCurrent(partial?: Partial<ExerciseEngineResult>) {
+    if (!currentItem) return
+
+    const result: ExerciseEngineResult = {
+      exerciseId: currentItem.exercise.id,
+      exerciseTitle: currentItem.exercise.title,
+      completed: true,
+      completionMode: currentItem.engine.measurable ? 'performance' : 'subjective',
+      durationSeconds: elapsedSeconds,
+      activeSeconds,
+      metrics: {},
+      finishedAt: new Date().toISOString(),
+      ...partial,
+    }
+
+    const nextResults = [...results.filter((item) => item.exerciseId !== result.exerciseId), result]
+    setResults(nextResults)
+    setPhase('result')
+
+    if (currentIndex < items.length - 1) {
+      window.setTimeout(() => {
+        const nextItem = items[currentIndex + 1]
+        setCurrentIndex((index) => index + 1)
+        setElapsedSeconds(0)
+        setActiveSeconds(0)
+        setPhase(getInitialPhase(nextItem?.engine))
+        setIsPaused(false)
+      }, 900)
+      return
+    }
+
+    await finishSession(nextResults)
+  }
+
+  async function finishSession(finalResults: ExerciseEngineResult[]) {
+    setSaving(true)
+    setSaveError(null)
+
+    let didSave = false
+    try {
+      if (saveContext) {
+        const response = await fetch('/api/vision/program', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action: 'complete_session',
+            data: {
+              week: saveContext.week,
+              day: saveContext.day,
+              baselineMinutes: saveContext.baselineMinutes,
+              exerciseMinutes: saveContext.exerciseMinutes,
+              exercisesCompleted: finalResults.map((result) => result.exerciseId),
+              nearSnellenResult: saveContext.nearSnellenResult || null,
+              farSnellenResult: saveContext.farSnellenResult || null,
+              notes: buildSessionNotes(saveContext.notes, finalResults),
+            },
+          }),
+        })
+
+        if (!response.ok) {
+          const body = await response.json().catch(() => null)
+          throw new Error(body?.error || 'Unable to save vision session')
+        }
+        didSave = true
+        setSaved(true)
+      }
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : 'Unable to save vision session')
+    } finally {
+      setSaving(false)
+    }
+
+    onComplete?.({
+      totalDurationSeconds: sessionElapsed,
+      activeDurationSeconds: finalResults.reduce((sum, item) => sum + item.activeSeconds, 0),
+      exercisesCompleted: finalResults.map((result) => result.exerciseId),
+      engineResults: finalResults,
+      saved: didSave,
+    })
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="bg-gradient-to-br from-gray-800/80 to-gray-900/80 backdrop-blur-sm rounded-xl p-5 border border-primary-400/20 shadow-lg">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <div className="text-xs uppercase tracking-wider text-primary-300 font-semibold">
+              Engine {currentIndex + 1} of {items.length}
+            </div>
+            <h2 className="text-2xl font-bold text-white mt-1">{currentItem.exercise.title}</h2>
+            <p className="text-gray-300 text-sm mt-1">{currentItem.engine.label} engine</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              onClick={() => setMuted((value) => !value)}
+              className="p-3 rounded-lg bg-gray-800/70 text-gray-200 hover:bg-gray-700/80"
+              title={muted ? 'Turn audio cues on' : 'Mute audio cues'}
+            >
+              {muted ? <VolumeX className="w-5 h-5" /> : <Volume2 className="w-5 h-5" />}
+            </button>
+            <button
+              onClick={restartCurrent}
+              className="p-3 rounded-lg bg-gray-800/70 text-gray-200 hover:bg-gray-700/80"
+              title="Restart this engine"
+            >
+              <RotateCcw className="w-5 h-5" />
+            </button>
+            {phase === 'intro' ? (
+              <button
+                onClick={startCurrent}
+                className="px-5 py-3 rounded-lg bg-gradient-to-r from-primary-500 to-secondary-500 text-white font-bold flex items-center gap-2"
+              >
+                <Play className="w-5 h-5" />
+                Start Engine
+              </button>
+            ) : (
+              <button
+                onClick={isPaused ? controls.resume : controls.pause}
+                disabled={phase !== 'active'}
+                className="px-5 py-3 rounded-lg bg-primary-600 disabled:opacity-50 text-white font-bold flex items-center gap-2"
+              >
+                {isPaused ? <Play className="w-5 h-5" /> : <Pause className="w-5 h-5" />}
+                {isPaused ? 'Resume' : 'Pause'}
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-5">
+          <div className="flex items-center justify-between text-xs text-gray-400 mb-2">
+            {displayOptions.hideNumericTimer ? (
+              <>
+                <span>Guided phase flow</span>
+                <span>{Math.round(progress)}% complete</span>
+              </>
+            ) : (
+              <>
+                <span>{formatTime(elapsedSeconds)} / {formatTime(currentDuration)}</span>
+                <span>{Math.round(progress)}%</span>
+              </>
+            )}
+          </div>
+          <div className="h-2 rounded-full overflow-hidden bg-gray-700">
+            <div
+              className="h-full bg-gradient-to-r from-primary-500 to-secondary-500 transition-all duration-500"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-2 md:grid-cols-3">
+          {items.map((item, index) => (
+            <div
+              key={item.exercise.id}
+              className={`rounded-lg border px-3 py-2 text-sm ${
+                completedIds.includes(item.exercise.id)
+                  ? 'border-secondary-400/40 bg-secondary-500/10 text-secondary-200'
+                  : index === currentIndex
+                    ? 'border-primary-400/50 bg-primary-500/10 text-white'
+                    : 'border-gray-700/50 bg-gray-900/40 text-gray-400'
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                {completedIds.includes(item.exercise.id) ? <CheckCircle className="w-4 h-4" /> : <Clock className="w-4 h-4" />}
+                {item.exercise.title}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <EngineComponent
+        exercise={currentItem.exercise}
+        difficulty={difficulty}
+        durationSeconds={currentDuration}
+        deviceMode={deviceMode}
+        reducedMotion={reducedMotion}
+        controls={controls}
+        onPhaseChange={setPhase}
+      />
+
+      {phase === 'result' && (
+        <div className="bg-secondary-600/15 border border-secondary-400/30 rounded-xl p-4 text-secondary-100 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <CheckCircle className="w-5 h-5" />
+            Engine result captured.
+          </div>
+          {currentIndex < items.length - 1 && (
+            <div className="flex items-center gap-2 text-sm">
+              Next engine
+              <ArrowRight className="w-4 h-4" />
+            </div>
+          )}
+        </div>
+      )}
+
+      {(saving || saved || saveError) && (
+        <div className="rounded-xl border border-primary-400/20 bg-gray-900/70 p-4 text-sm">
+          {saving && <span className="text-gray-300">Saving session record...</span>}
+          {saved && <span className="text-secondary-300">Session record saved.</span>}
+          {saveError && <span className="text-red-300">{saveError}</span>}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function formatTime(seconds: number) {
+  const mins = Math.floor(seconds / 60)
+  const secs = seconds % 60
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+
+function getInitialPhase(engine?: ExerciseEngineDefinition): ExerciseLifecyclePhase {
+  return engine?.displayOptions?.autoStart ? 'active' : 'intro'
+}
+
+function buildSessionNotes(notes: string | null | undefined, results: ExerciseEngineResult[]) {
+  const engineSummary = results
+    .map((result) => `${result.exerciseTitle}: ${result.activeSeconds}s active, ${Object.entries(result.metrics).map(([key, value]) => `${key}=${value}`).join(', ') || 'completed'}`)
+    .join(' | ')
+
+  return [notes, `Engine results: ${engineSummary}`].filter(Boolean).join('\n')
+}

--- a/src/components/Vision/Engines/SmoothTrackingEngine.tsx
+++ b/src/components/Vision/Engines/SmoothTrackingEngine.tsx
@@ -1,0 +1,302 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Activity, CheckCircle, Circle, Eye, Pause, Play, RotateCcw, Volume2 } from 'lucide-react'
+import type { ExerciseEngineDefinition, ExerciseEngineProps } from './types'
+
+type TrackingPattern = 'horizontal' | 'vertical' | 'circle' | 'figure8'
+
+const PATTERNS: { id: TrackingPattern; label: string; cue: string }[] = [
+  { id: 'horizontal', label: 'Horizontal glide', cue: 'Follow side to side with eyes only.' },
+  { id: 'vertical', label: 'Vertical lift', cue: 'Track up and down without lifting your chin.' },
+  { id: 'circle', label: 'Circle pursuit', cue: 'Keep the motion round and unbroken.' },
+  { id: 'figure8', label: 'Figure-8 flow', cue: 'Let your eyes draw a smooth infinity sign.' },
+]
+
+const DIFFICULTY_SPEED: Record<ExerciseEngineProps['difficulty'], number> = {
+  starter: 9000,
+  standard: 7000,
+  challenge: 5400,
+  advanced: 4200,
+}
+
+const DIFFICULTY_PACE: Record<ExerciseEngineProps['difficulty'], string> = {
+  starter: 'Level 1',
+  standard: 'Level 2',
+  challenge: 'Level 3',
+  advanced: 'Level 4',
+}
+
+export const smoothTrackingEngine: ExerciseEngineDefinition = {
+  id: 'smooth-tracking-v1',
+  label: 'Smooth Tracking',
+  sourceExerciseId: 'smooth-tracking',
+  supportedDeviceModes: ['phone', 'desktop'],
+  measurable: true,
+  defaultDurationSeconds: 180,
+  displayOptions: {
+    autoStart: true,
+    hideNumericTimer: true,
+  },
+  component: SmoothTrackingEngine,
+}
+
+export default function SmoothTrackingEngine({
+  exercise,
+  difficulty,
+  durationSeconds,
+  deviceMode,
+  reducedMotion,
+  controls,
+}: ExerciseEngineProps) {
+  const surfaceRef = useRef<HTMLDivElement | null>(null)
+  const animationRef = useRef<number | null>(null)
+  const startedAtRef = useRef<number>(0)
+  const [patternIndex, setPatternIndex] = useState(0)
+  const [position, setPosition] = useState({ x: 50, y: 50 })
+  const [loopsCompleted, setLoopsCompleted] = useState(0)
+  const [audioEnabled, setAudioEnabled] = useState(true)
+  const completedRef = useRef(false)
+  const pattern = PATTERNS[patternIndex]
+  const cycleMs = DIFFICULTY_SPEED[difficulty]
+  const paceLabel = DIFFICULTY_PACE[difficulty]
+
+  const targetSize = deviceMode === 'phone' ? 34 : 42
+  const pathScale = deviceMode === 'phone' ? 0.78 : 0.86
+
+  const phaseLabel = useMemo(() => {
+    if (controls.phase === 'intro') return 'Set your head still, soften your jaw, and prepare to track.'
+    if (controls.phase === 'cooldown') return 'Blink slowly, look around the room, and let your eyes soften.'
+    if (controls.phase === 'result') return 'Smooth Tracking complete.'
+    return pattern.cue
+  }, [controls.phase, pattern.cue])
+
+  useEffect(() => {
+    if (!audioEnabled || controls.phase !== 'active' || controls.isPaused || typeof window === 'undefined') return
+    if (!('speechSynthesis' in window)) return
+
+    window.speechSynthesis.cancel()
+    const utterance = new SpeechSynthesisUtterance(pattern.cue)
+    utterance.rate = 0.92
+    utterance.pitch = 1
+    utterance.volume = 0.75
+    window.speechSynthesis.speak(utterance)
+  }, [audioEnabled, controls.phase, controls.isPaused, pattern.cue])
+
+  useEffect(() => {
+    if (controls.phase !== 'active' || controls.isPaused || reducedMotion) return
+
+    const animate = (now: number) => {
+      if (!startedAtRef.current) startedAtRef.current = now
+      const elapsed = now - startedAtRef.current
+      const normalized = (elapsed % cycleMs) / cycleMs
+      const completedLoops = Math.floor(elapsed / cycleMs)
+      setLoopsCompleted(completedLoops)
+
+      const pathPosition = getPatternPosition(pattern.id, normalized, pathScale)
+      setPosition(pathPosition)
+
+      const nextIndex = Math.floor((controls.progress / 100) * PATTERNS.length)
+      setPatternIndex(Math.min(PATTERNS.length - 1, nextIndex))
+
+      animationRef.current = requestAnimationFrame(animate)
+    }
+
+    animationRef.current = requestAnimationFrame(animate)
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current)
+      }
+    }
+  }, [controls.phase, controls.isPaused, controls.progress, cycleMs, pattern.id, pathScale, reducedMotion])
+
+  useEffect(() => {
+    if (controls.phase !== 'active' || !reducedMotion) return
+    const step = window.setInterval(() => {
+      setPatternIndex((current) => (current + 1) % PATTERNS.length)
+      setPosition((current) => ({
+        x: current.x === 35 ? 65 : 35,
+        y: current.y === 42 ? 58 : 42,
+      }))
+    }, 2200)
+    return () => window.clearInterval(step)
+  }, [controls.phase, reducedMotion])
+
+  useEffect(() => {
+    if (controls.phase !== 'active') {
+      completedRef.current = false
+      if (controls.phase === 'intro') {
+        startedAtRef.current = 0
+        setLoopsCompleted(0)
+        setPatternIndex(0)
+        setPosition({ x: 50, y: 50 })
+      }
+    }
+  }, [controls.phase])
+
+  const completeWithMetrics = () => {
+    if (completedRef.current) return
+    completedRef.current = true
+
+    controls.complete({
+      completionMode: 'performance',
+      metrics: {
+        patternsPracticed: PATTERNS.slice(0, patternIndex + 1).map((item) => item.id).join(', '),
+        loopsCompleted,
+        speedMsPerLoop: cycleMs,
+        reducedMotion,
+      },
+    })
+  }
+
+  useEffect(() => {
+    if (controls.phase === 'active' && controls.remainingSeconds <= 1) {
+      completeWithMetrics()
+    }
+  }, [controls.phase, controls.remainingSeconds])
+
+  return (
+    <div className="space-y-5">
+      <div className="bg-gradient-to-br from-gray-800/80 to-gray-900/80 backdrop-blur-sm rounded-xl p-5 border border-primary-400/20 shadow-lg">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <div className="flex items-center gap-2 text-primary-300 text-sm font-semibold mb-1">
+              <Eye className="w-4 h-4" />
+              Reference engine
+            </div>
+            <h3 className="text-2xl font-bold text-white">{exercise.title}</h3>
+            <p className="text-gray-300 mt-2 max-w-2xl">
+              Follow the moving target with eye motion only while the path changes automatically.
+            </p>
+          </div>
+          <div className="grid grid-cols-3 gap-2 text-center text-xs">
+            <div className="rounded-lg bg-gray-950/50 px-3 py-2 border border-gray-700/50">
+              <div className="text-gray-400">Pattern</div>
+              <div className="text-white font-semibold">{patternIndex + 1}/{PATTERNS.length}</div>
+            </div>
+            <div className="rounded-lg bg-gray-950/50 px-3 py-2 border border-gray-700/50">
+              <div className="text-gray-400">Loops</div>
+              <div className="text-white font-semibold">{loopsCompleted}</div>
+            </div>
+            <div className="rounded-lg bg-gray-950/50 px-3 py-2 border border-gray-700/50">
+              <div className="text-gray-400">Pace</div>
+              <div className="text-white font-semibold">{paceLabel}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div
+        ref={surfaceRef}
+        className="relative overflow-hidden rounded-xl border border-primary-400/20 bg-[radial-gradient(circle_at_center,rgba(63,191,181,0.18),rgba(17,24,39,0.96)_58%)] shadow-2xl"
+        style={{ minHeight: deviceMode === 'phone' ? 360 : 460 }}
+      >
+        <div className="absolute inset-5 rounded-full border border-primary-300/15" />
+        <div className="absolute left-1/2 top-8 bottom-8 w-px bg-primary-300/10" />
+        <div className="absolute top-1/2 left-8 right-8 h-px bg-primary-300/10" />
+        <svg className="absolute inset-0 h-full w-full" aria-hidden="true">
+          <path
+            d="M 14 50 C 25 25, 41 25, 50 50 S 75 75, 86 50 C 75 25, 59 25, 50 50 S 25 75, 14 50"
+            fill="none"
+            stroke="rgba(63, 191, 181, 0.24)"
+            strokeWidth="1.5"
+            vectorEffect="non-scaling-stroke"
+          />
+          <circle cx="50%" cy="50%" r="28%" fill="none" stroke="rgba(114, 194, 71, 0.16)" strokeWidth="1.5" />
+        </svg>
+
+        <div
+          className="absolute rounded-full shadow-[0_0_34px_rgba(114,194,71,0.55)] transition-colors duration-300"
+          style={{
+            left: `${position.x}%`,
+            top: `${position.y}%`,
+            width: targetSize,
+            height: targetSize,
+            transform: 'translate(-50%, -50%)',
+            background: 'radial-gradient(circle at 35% 35%, #ffffff 0 8%, #72C247 9% 44%, #3FBFB5 45% 100%)',
+          }}
+        >
+          <div className="absolute inset-[-10px] rounded-full border border-secondary-300/30" />
+        </div>
+
+        <div className="absolute left-4 right-4 top-4 flex flex-wrap items-center justify-between gap-3">
+          <div className="sr-only" aria-live="polite">{phaseLabel}</div>
+          <div className="flex items-center gap-2 rounded-lg bg-gray-950/70 px-3 py-2 backdrop-blur-sm border border-primary-400/20">
+            <Activity className="w-4 h-4 text-secondary-300" />
+            <span className="text-sm text-white">{pattern.label}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-4">
+        {PATTERNS.map((item, index) => (
+          <div
+            key={item.id}
+            className={`rounded-lg border px-4 py-3 ${
+              index === patternIndex
+                ? 'border-secondary-400/50 bg-secondary-500/15 text-white'
+                : index < patternIndex
+                  ? 'border-primary-400/30 bg-primary-500/10 text-gray-200'
+                  : 'border-gray-700/40 bg-gray-900/50 text-gray-400'
+            }`}
+          >
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              {index < patternIndex ? <CheckCircle className="w-4 h-4" /> : <Circle className="w-4 h-4" />}
+              {item.label}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <button
+          onClick={controls.restart}
+          className="px-4 py-3 rounded-lg bg-gray-700/80 hover:bg-gray-600/80 text-white font-semibold flex items-center gap-2 transition-all"
+        >
+          <RotateCcw className="w-5 h-5" />
+          Restart
+        </button>
+        <button
+          onClick={controls.isPaused ? controls.resume : controls.pause}
+          disabled={controls.phase !== 'active'}
+          className="px-5 py-3 rounded-lg bg-primary-600 hover:bg-primary-700 disabled:opacity-50 disabled:hover:bg-primary-600 text-white font-semibold flex items-center gap-2 transition-all"
+        >
+          {controls.isPaused ? <Play className="w-5 h-5" /> : <Pause className="w-5 h-5" />}
+          {controls.isPaused ? 'Resume' : 'Pause'}
+        </button>
+        <button
+          onClick={() => setAudioEnabled((enabled) => !enabled)}
+          className={`px-4 py-3 rounded-lg font-semibold flex items-center gap-2 transition-all ${
+            audioEnabled ? 'bg-secondary-600 text-white' : 'bg-gray-800 text-gray-300'
+          }`}
+        >
+          <Volume2 className="w-5 h-5" />
+          Cues
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function getPatternPosition(pattern: TrackingPattern, progress: number, scale: number) {
+  const theta = progress * Math.PI * 2
+  const width = 36 * scale
+  const height = 30 * scale
+
+  if (pattern === 'horizontal') {
+    return { x: 50 + Math.cos(theta) * width, y: 50 }
+  }
+
+  if (pattern === 'vertical') {
+    return { x: 50, y: 50 + Math.sin(theta) * height }
+  }
+
+  if (pattern === 'circle') {
+    return { x: 50 + Math.cos(theta) * width * 0.72, y: 50 + Math.sin(theta) * height }
+  }
+
+  return {
+    x: 50 + Math.sin(theta) * width,
+    y: 50 + Math.sin(theta * 2) * height * 0.55,
+  }
+}

--- a/src/components/Vision/Engines/index.ts
+++ b/src/components/Vision/Engines/index.ts
@@ -1,0 +1,17 @@
+import type { VisionExercise } from '@/data/visionExercises'
+import type { ExerciseEngineDefinition } from './types'
+import { createGuidedStimulusEngine } from './GuidedStimulusEngine'
+import { smoothTrackingEngine } from './SmoothTrackingEngine'
+
+export { default as SessionRunner } from './SessionRunner'
+export { default as GuidedStimulusEngine, createGuidedStimulusEngine } from './GuidedStimulusEngine'
+export { default as SmoothTrackingEngine, smoothTrackingEngine } from './SmoothTrackingEngine'
+export * from './types'
+
+const ENGINE_REGISTRY: Record<string, ExerciseEngineDefinition> = {
+  [smoothTrackingEngine.sourceExerciseId]: smoothTrackingEngine,
+}
+
+export function getEngineForExercise(exercise: VisionExercise): ExerciseEngineDefinition {
+  return ENGINE_REGISTRY[exercise.id] || createGuidedStimulusEngine(exercise)
+}

--- a/src/components/Vision/Engines/types.ts
+++ b/src/components/Vision/Engines/types.ts
@@ -1,0 +1,81 @@
+import type { ComponentType } from 'react'
+import type { VisionExercise } from '@/data/visionExercises'
+
+export type ExerciseDeviceMode = 'phone' | 'desktop'
+
+export type ExerciseDifficulty = 'starter' | 'standard' | 'challenge' | 'advanced'
+
+export type ExerciseLifecyclePhase = 'intro' | 'active' | 'cooldown' | 'result'
+
+export type ExerciseCompletionMode = 'performance' | 'subjective'
+
+export type ExerciseMetricValue = string | number | boolean
+
+export type ExerciseMetrics = Record<string, ExerciseMetricValue>
+
+export interface ExerciseEngineResult {
+  exerciseId: string
+  exerciseTitle: string
+  completed: boolean
+  completionMode: ExerciseCompletionMode
+  durationSeconds: number
+  activeSeconds: number
+  metrics: ExerciseMetrics
+  notes?: string
+  finishedAt: string
+}
+
+export interface ExerciseEngineControls {
+  phase: ExerciseLifecyclePhase
+  isPaused: boolean
+  elapsedSeconds: number
+  remainingSeconds: number
+  progress: number
+  pause: () => void
+  resume: () => void
+  restart: () => void
+  complete: (result?: Partial<ExerciseEngineResult>) => void
+}
+
+export interface ExerciseEngineProps {
+  exercise: VisionExercise
+  difficulty: ExerciseDifficulty
+  durationSeconds: number
+  deviceMode: ExerciseDeviceMode
+  reducedMotion: boolean
+  autoStart?: boolean
+  controls: ExerciseEngineControls
+  onPhaseChange?: (phase: ExerciseLifecyclePhase) => void
+}
+
+export interface ExerciseEngineDefinition {
+  id: string
+  label: string
+  sourceExerciseId: string
+  supportedDeviceModes: ExerciseDeviceMode[]
+  measurable: boolean
+  defaultDurationSeconds: number
+  displayOptions?: {
+    autoStart?: boolean
+    hideNumericTimer?: boolean
+  }
+  component: ComponentType<ExerciseEngineProps>
+}
+
+export interface SessionRunnerSaveContext {
+  week: number
+  day: number
+  baselineMinutes: number
+  exerciseMinutes: number
+  nearSnellenResult?: string | null
+  farSnellenResult?: string | null
+  notes?: string | null
+}
+
+export interface SessionRunnerResult {
+  totalDurationSeconds: number
+  activeDurationSeconds: number
+  exercisesCompleted: string[]
+  engineResults: ExerciseEngineResult[]
+  saved: boolean
+}

--- a/src/components/Vision/Training/DailyPractice.tsx
+++ b/src/components/Vision/Training/DailyPractice.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import {
   Clock,
   CheckCircle,
@@ -14,6 +14,7 @@ import {
   BookOpen
 } from 'lucide-react'
 import TrainingSession from './TrainingSession'
+import { SessionRunner, getEngineForExercise } from '@/components/Vision/Engines'
 
 interface DailySession {
   day: number
@@ -78,7 +79,6 @@ export default function DailyPractice() {
   const [enrollment, setEnrollment] = useState<Enrollment | null>(null)
   const [todaySession, setTodaySession] = useState<TodaySessionData | null>(null)
   const [programInfo, setProgramInfo] = useState<ProgramInfo | null>(null)
-  const [activeExercise, setActiveExercise] = useState<number>(0)
   const [sessionStarted, setSessionStarted] = useState(false)
   const [baselineComplete, setBaselineComplete] = useState(false)
   const [completedExercises, setCompletedExercises] = useState<string[]>([])
@@ -87,6 +87,14 @@ export default function DailyPractice() {
   const [nearSnellenResult, setNearSnellenResult] = useState('')
   const [farSnellenResult, setFarSnellenResult] = useState('')
   const [enrolling, setEnrolling] = useState(false)
+
+  const engineItems = useMemo(() => {
+    const exercises = todaySession?.session?.exercises || []
+    return exercises.map((exercise: any) => ({
+      exercise,
+      engine: getEngineForExercise(exercise),
+    }))
+  }, [todaySession?.session?.exercises])
 
   useEffect(() => {
     loadProgram()
@@ -136,47 +144,6 @@ export default function DailyPractice() {
       console.error('Failed to enroll:', error)
     } finally {
       setEnrolling(false)
-    }
-  }
-
-  const completeExercise = (exerciseId: string) => {
-    if (!completedExercises.includes(exerciseId)) {
-      setCompletedExercises([...completedExercises, exerciseId])
-    }
-    // Move to next exercise
-    if (todaySession?.session?.exercises && activeExercise < todaySession.session.exercises.length - 1) {
-      setActiveExercise(activeExercise + 1)
-    }
-  }
-
-  const completeSession = async () => {
-    if (!todaySession?.session || !enrollment) return
-
-    try {
-      const response = await fetch('/api/vision/program', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          action: 'complete_session',
-          data: {
-            week: todaySession.week,
-            day: todaySession.day,
-            baselineMinutes: todaySession.session.baselineMinutes,
-            exerciseMinutes: todaySession.session.exerciseMinutes,
-            exercisesCompleted: completedExercises,
-            nearSnellenResult: nearSnellenResult || null,
-            farSnellenResult: farSnellenResult || null,
-            notes: sessionNotes || null
-          }
-        })
-      })
-
-      const data = await response.json()
-      if (data.success) {
-        loadProgram() // Reload to show completion
-      }
-    } catch (error) {
-      console.error('Failed to complete session:', error)
     }
   }
 
@@ -417,7 +384,7 @@ export default function DailyPractice() {
                 <span className="text-xs font-semibold text-primary-400 uppercase tracking-wider">
                   {todaySession.phase}
                 </span>
-                <span className="text-gray-500">•</span>
+                <span className="text-gray-500">&bull;</span>
                 <span className="text-xs text-gray-400">
                   Week {todaySession.week}, Day {todaySession.day}
                 </span>
@@ -447,7 +414,7 @@ export default function DailyPractice() {
                 <ul className="space-y-1">
                   {todaySession.weekGoals.map((goal, idx) => (
                     <li key={idx} className="text-gray-300 text-sm flex items-start gap-2">
-                      <span className="text-primary-400">•</span>
+                      <span className="text-primary-400">&bull;</span>
                       {goal}
                     </li>
                   ))}
@@ -506,7 +473,7 @@ export default function DailyPractice() {
                 </h4>
                 <ul className="space-y-1">
                   {session.coachingCues.map((cue, idx) => (
-                    <li key={idx} className="text-yellow-200/80 text-sm">• {cue}</li>
+                    <li key={idx} className="text-yellow-200/80 text-sm">&bull; {cue}</li>
                   ))}
                 </ul>
               </div>
@@ -596,86 +563,17 @@ export default function DailyPractice() {
                 </div>
               )}
 
-              {/* Phase 2: Exercises */}
+              {/* Phase 2: Interactive engines */}
               {baselineComplete && (
                 <div className="space-y-4">
                   <div className="flex items-center justify-between mb-2">
                     <h4 className="text-white font-bold text-lg flex items-center gap-2">
                       <Zap className="w-5 h-5 text-secondary-400" />
-                      Step 2: Exercises
+                      Step 2: Interactive Engines
                     </h4>
                     <span className="text-sm text-gray-400">
                       {completedExercises.length}/{session.exercises.length} complete
                     </span>
-                  </div>
-
-                  {/* Exercise list */}
-                  <div className="space-y-3">
-                    {session.exercises.map((exercise: any, idx: number) => {
-                      const isCompleted = completedExercises.includes(exercise.id)
-                      const isActive = idx === activeExercise
-
-                      return (
-                        <div
-                          key={exercise.id}
-                          className={`rounded-lg p-4 transition-all ${
-                            isCompleted
-                              ? 'bg-secondary-500/20 border border-secondary-400/30'
-                              : isActive
-                              ? 'bg-primary-500/20 border border-primary-400/50'
-                              : 'bg-gray-800/30 border border-gray-700/30'
-                          }`}
-                        >
-                          <div className="flex items-start justify-between">
-                            <div className="flex items-start gap-3">
-                              <div className={`w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0 ${
-                                isCompleted ? 'bg-secondary-500' : isActive ? 'bg-primary-500' : 'bg-gray-700'
-                              }`}>
-                                {isCompleted ? (
-                                  <CheckCircle className="w-4 h-4 text-white" />
-                                ) : (
-                                  <span className="text-xs text-white">{idx + 1}</span>
-                                )}
-                              </div>
-                              <div>
-                                <div className="text-white font-semibold">{exercise.title}</div>
-                                <div className="text-gray-400 text-sm">{exercise.duration} • {exercise.category}</div>
-                                {isActive && !isCompleted && (
-                                  <p className="text-gray-300 text-sm mt-2">{exercise.summary}</p>
-                                )}
-                              </div>
-                            </div>
-                            {!isCompleted && (
-                              <button
-                                onClick={() => completeExercise(exercise.id)}
-                                className={`px-3 py-1 rounded text-sm font-medium ${
-                                  isActive
-                                    ? 'bg-secondary-500 hover:bg-secondary-600 text-white'
-                                    : 'bg-gray-700 hover:bg-gray-600 text-gray-300'
-                                }`}
-                              >
-                                {isActive ? 'Complete' : 'Mark Done'}
-                              </button>
-                            )}
-                          </div>
-
-                          {/* Expanded view for active exercise */}
-                          {isActive && !isCompleted && exercise.checkpoints && (
-                            <div className="mt-4 pt-4 border-t border-gray-700/50">
-                              <div className="text-sm text-gray-400 mb-2">Checkpoints:</div>
-                              <ul className="space-y-1">
-                                {exercise.checkpoints.slice(0, 3).map((checkpoint: string, cidx: number) => (
-                                  <li key={cidx} className="text-gray-300 text-sm flex items-start gap-2">
-                                    <span className="text-primary-400">•</span>
-                                    {checkpoint}
-                                  </li>
-                                ))}
-                              </ul>
-                            </div>
-                          )}
-                        </div>
-                      )
-                    })}
                   </div>
 
                   {/* Session notes */}
@@ -690,15 +588,25 @@ export default function DailyPractice() {
                     />
                   </div>
 
-                  {/* Complete session button */}
-                  {completedExercises.length === session.exercises.length && (
-                    <button
-                      onClick={completeSession}
-                      className="w-full py-4 bg-gradient-to-r from-secondary-500 to-primary-500 hover:from-secondary-600 hover:to-primary-600 text-white font-bold text-lg rounded-xl transition-all flex items-center justify-center gap-2 mt-4"
-                    >
-                      <Trophy className="w-5 h-5" />
-                      Complete Today's Session
-                    </button>
+                  {engineItems.length > 0 && (
+                    <SessionRunner
+                      items={engineItems}
+                      deviceMode="phone"
+                      difficulty="standard"
+                      saveContext={{
+                        week: todaySession.week,
+                        day: todaySession.day,
+                        baselineMinutes: session.baselineMinutes,
+                        exerciseMinutes: session.exerciseMinutes,
+                        nearSnellenResult: nearSnellenResult || null,
+                        farSnellenResult: farSnellenResult || null,
+                        notes: sessionNotes || null,
+                      }}
+                      onComplete={(result) => {
+                        setCompletedExercises(result.exercisesCompleted)
+                        if (result.saved) loadProgram()
+                      }}
+                    />
                   )}
                 </div>
               )}

--- a/src/components/Vision/Training/QuickPractice.tsx
+++ b/src/components/Vision/Training/QuickPractice.tsx
@@ -14,8 +14,8 @@ import {
   Waves
 } from 'lucide-react'
 import { visionExercises, VisionExercise } from '@/data/visionExercises'
-import GuidedExercise from './GuidedExercise'
 import GaborTraining from './GaborTraining'
+import { SessionRunner, getEngineForExercise } from '@/components/Vision/Engines'
 
 const CATEGORY_CONFIG = {
   downshift: { icon: Eye, color: 'blue', label: 'Relaxation' },
@@ -54,8 +54,13 @@ export default function QuickPractice() {
   // Show guided exercise if one is selected
   if (selectedExercise) {
     return (
-      <GuidedExercise
-        exercise={selectedExercise}
+      <SessionRunner
+        items={[{
+          exercise: selectedExercise,
+          engine: getEngineForExercise(selectedExercise),
+        }]}
+        deviceMode="phone"
+        difficulty="standard"
         onComplete={handleExerciseComplete}
         onBack={() => setSelectedExercise(null)}
       />


### PR DESCRIPTION
## Summary
- Adds `docs/vision-exercise-specs.md` with 30 extracted/specifiable ScreenFit exercises and extraction limitations logged.
- Introduces a reusable `ExerciseEngine` contract, `SessionRunner`, and engine registry for Vision Training.
- Replaces Daily Practice and Vision Library quick practice manual-completion flows with the session runner.
- Implements Smooth Tracking as the reference interactive engine with animated pursuit paths, auto-start timed phases, audio cues, pace progression, and captured metrics.

## Acceptance Evidence
- Worklist issue: jonchyatt/codex-worklist#12
- Typecheck: `npx tsc --noEmit` -> exit 0
- Build: `npm run build` -> exit 0; compiled with pre-existing Auth0 env/workspace-root warnings.
- Browser check: `/vision-training` -> Vision Library -> Smooth Tracking auto-started; moving target present; no countdown format; no `Complete Engine` or `Mark Done` action.
- Scope guard: Snellen/Gabor/Binocular trainer files were not modified.

## Risk
- The generic scaffold engine is intentionally broad so future issues can replace categories with specialized engines without returning to manual completion cards.