### PR TITLE
[worklist#22] RB Audio: singing-game baseline and volume slider audit

### DIFF
--- a/src/components/PitchDefender/ChoirPractice.tsx
+++ b/src/components/PitchDefender/ChoirPractice.tsx
@@ -23,7 +23,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { NOTE_COLORS } from '@/lib/fsrs'
 import { PitchFusion, type FusedPitch, DEFAULT_FUSION_CONFIG } from './pitchFusion'
-import { initAudio, playPianoNote } from './audioEngine'
+import { initAudio, playPianoNote, markToneEmitted } from './audioEngine'
 import { extractMelodyFromComposition, compositionHasNotes } from './composerExtract'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -47,6 +47,7 @@ interface PracticeConfig {
   loopEnd: number       // measure number (0 = disabled)
   guideVolume: number   // 0 to 1
   selfFeedback: boolean // mic → speaker
+  selfFeedbackVolume: number // 0 to 2
   guidePan: number      // -1 = left, 0 = center, 1 = right
   voicePan: number      // -1 = left, 0 = center, 1 = right
 }
@@ -97,6 +98,8 @@ function playGuideNote(semi: number, durationMs: number, volume: number, pan: nu
   const now = ctx.currentTime
   const freq = semitonesToFreq(semi)
   const durSec = durationMs / 1000
+  const gainScale = Math.max(0, Math.min(2, volume))
+  markToneEmitted(durationMs + 100)
 
   // Triangle + slight detune for warm tone
   const osc1 = ctx.createOscillator()
@@ -111,8 +114,8 @@ function playGuideNote(semi: number, durationMs: number, volume: number, pan: nu
   // Envelope
   const gain = ctx.createGain()
   gain.gain.setValueAtTime(0, now)
-  gain.gain.linearRampToValueAtTime(volume * 0.2, now + 0.02)
-  gain.gain.setValueAtTime(volume * 0.15, now + Math.min(durSec * 0.8, durSec - 0.05))
+  gain.gain.linearRampToValueAtTime(gainScale * 0.2, now + 0.02)
+  gain.gain.setValueAtTime(gainScale * 0.15, now + Math.min(durSec * 0.8, durSec - 0.05))
   gain.gain.exponentialRampToValueAtTime(0.001, now + durSec)
 
   // Panning
@@ -132,7 +135,7 @@ function playGuideNote(semi: number, durationMs: number, volume: number, pan: nu
 
 let _feedbackRequestId = 0 // [FIX HIGH] Guard async mic resolution
 
-function startSelfFeedback(pan: number) {
+function startSelfFeedback(pan: number, volume: number) {
   stopSelfFeedback()
   const ctx = getGuideCtx()
   const requestId = ++_feedbackRequestId
@@ -146,7 +149,7 @@ function startSelfFeedback(pan: number) {
       _feedbackStream = stream
       _feedbackSource = ctx.createMediaStreamSource(stream)
       _feedbackGain = ctx.createGain()
-      _feedbackGain.gain.value = 0.7
+      _feedbackGain.gain.value = Math.max(0, Math.min(2, volume))
       _feedbackPanner = ctx.createStereoPanner()
       _feedbackPanner.pan.value = pan
       _feedbackSource.connect(_feedbackGain)
@@ -166,6 +169,10 @@ function stopSelfFeedback() {
 
 function updateFeedbackPan(pan: number) {
   if (_feedbackPanner) _feedbackPanner.pan.value = pan
+}
+
+function updateFeedbackVolume(volume: number) {
+  if (_feedbackGain) _feedbackGain.gain.value = Math.max(0, Math.min(2, volume))
 }
 
 // ─── OSMD Note Extraction ───────────────────────────────────────────────────
@@ -332,6 +339,7 @@ export default function ChoirPractice() {
     loopEnd: 0,
     guideVolume: 0.8,
     selfFeedback: false,
+    selfFeedbackVolume: 1,
     guidePan: -0.7,   // guide in left ear
     voicePan: 0.7,     // self in right ear
   })
@@ -351,6 +359,10 @@ export default function ChoirPractice() {
   useEffect(() => { configRef.current = config }, [config])
   useEffect(() => { statsRef.current = practiceStats }, [practiceStats])
   useEffect(() => { currentIdxRef.current = currentIdx }, [currentIdx])
+  useEffect(() => {
+    updateFeedbackPan(config.voicePan)
+    updateFeedbackVolume(config.selfFeedbackVolume)
+  }, [config.voicePan, config.selfFeedbackVolume])
 
   // Refresh saved-composition list whenever we're in upload phase.
   // Uses the shared composerExtract module — handles BOTH the new measures
@@ -564,7 +576,7 @@ export default function ChoirPractice() {
 
     // Start self-feedback if enabled
     if (config.selfFeedback) {
-      startSelfFeedback(config.voicePan)
+      startSelfFeedback(config.voicePan, config.selfFeedbackVolume)
     }
 
     setPhase('practicing')
@@ -933,9 +945,10 @@ export default function ChoirPractice() {
           <div className="space-y-2">
             <div className="flex items-center justify-between">
               <span className="text-xs text-gray-400">Guide volume</span>
-              <input type="range" min={0} max={100} value={config.guideVolume * 100}
+              <input type="range" min={0} max={200} value={config.guideVolume * 100}
                 onChange={e => setConfig(p => ({ ...p, guideVolume: Number(e.target.value) / 100 }))}
                 className="w-32 h-1 accent-indigo-500" />
+              <span className="text-xs text-indigo-300 font-mono w-10 text-right">{Math.round(config.guideVolume * 100)}%</span>
             </div>
             <div className="flex items-center justify-between">
               <span className="text-xs text-gray-400">Self-feedback (hear yourself)</span>
@@ -966,22 +979,31 @@ export default function ChoirPractice() {
               </div>
             </div>
             {config.selfFeedback && (
-              <div className="flex items-center justify-between">
-                <span className="text-xs text-gray-400">Stereo: Voice</span>
-                <div className="flex gap-1">
-                  {[{ label: 'L', val: -0.9 }, { label: 'C', val: 0 }, { label: 'R', val: 0.9 }].map(o => (
-                    <button key={o.label} onClick={() => setConfig(p => ({ ...p, voicePan: o.val }))}
-                      className="px-2 py-0.5 rounded text-[10px] transition-all"
-                      style={{
-                        background: Math.abs(config.voicePan - o.val) < 0.2 ? 'rgba(99,102,241,0.2)' : 'transparent',
-                        border: `1px solid ${Math.abs(config.voicePan - o.val) < 0.2 ? 'rgba(99,102,241,0.4)' : 'rgba(60,60,80,0.3)'}`,
-                        color: Math.abs(config.voicePan - o.val) < 0.2 ? '#a5b4fc' : '#666',
-                      }}>
-                      {o.label}
-                    </button>
-                  ))}
+              <>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-gray-400">Voice volume</span>
+                  <input type="range" min={0} max={200} value={config.selfFeedbackVolume * 100}
+                    onChange={e => setConfig(p => ({ ...p, selfFeedbackVolume: Number(e.target.value) / 100 }))}
+                    className="w-32 h-1 accent-cyan-500" />
+                  <span className="text-xs text-cyan-300 font-mono w-10 text-right">{Math.round(config.selfFeedbackVolume * 100)}%</span>
                 </div>
-              </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-gray-400">Stereo: Voice</span>
+                  <div className="flex gap-1">
+                    {[{ label: 'L', val: -0.9 }, { label: 'C', val: 0 }, { label: 'R', val: 0.9 }].map(o => (
+                      <button key={o.label} onClick={() => setConfig(p => ({ ...p, voicePan: o.val }))}
+                        className="px-2 py-0.5 rounded text-[10px] transition-all"
+                        style={{
+                          background: Math.abs(config.voicePan - o.val) < 0.2 ? 'rgba(99,102,241,0.2)' : 'transparent',
+                          border: `1px solid ${Math.abs(config.voicePan - o.val) < 0.2 ? 'rgba(99,102,241,0.4)' : 'rgba(60,60,80,0.3)'}`,
+                          color: Math.abs(config.voicePan - o.val) < 0.2 ? '#a5b4fc' : '#666',
+                        }}>
+                        {o.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </>
             )}
           </div>
         </div>

--- a/src/components/PitchDefender/DrillMode.tsx
+++ b/src/components/PitchDefender/DrillMode.tsx
@@ -20,7 +20,7 @@ import { INTRO_ORDER, UNLOCK_THRESHOLDS } from './types'
 import NoteButtons from './NoteButtons'
 import PitchGuidance from './PitchGuidance'
 import { usePitchDetection } from './usePitchDetection'
-import { initAudio, loadPianoSamples, playPianoNote } from './audioEngine'
+import { initAudio, loadPianoSamples, playPianoNote, setPianoVolume } from './audioEngine'
 import { noteToFreq, octaveFoldedCents, PITCH_ON_TOLERANCE_CENTS } from './pitchMath'
 
 // ─── Constants ──────────────────────────────────────────────────────────────
@@ -65,6 +65,7 @@ export default function DrillMode() {
   const [sessionTarget, setSessionTarget] = useState(20) // cards per session
   const [lockProgress, setLockProgress] = useState(0)
   const [autoPlay, setAutoPlay] = useState(true) // auto-play note on new card
+  const [guideVolume, setGuideVolume] = useState(100)
 
   // Refs
   const fsrsRef = useRef<Record<string, NoteMemory>>({})
@@ -84,6 +85,7 @@ export default function DrillMode() {
   // Keep refs in sync with state
   useEffect(() => { sessionStatsRef.current = sessionStats }, [sessionStats])
   useEffect(() => { unlockedNotesRef.current = unlockedNotes }, [unlockedNotes])
+  useEffect(() => { setPianoVolume(guideVolume) }, [guideVolume])
 
   // Timer management — schedule + track for cleanup
   const scheduleTimer = useCallback((fn: () => void, ms: number) => {
@@ -469,6 +471,19 @@ export default function DrillMode() {
             className="w-4 h-4 rounded accent-teal-500"
           />
           <span className="text-xs text-gray-400">Auto-play note on each card</span>
+        </label>
+
+        <label className="flex items-center gap-3 mb-6">
+          <span className="text-xs text-gray-500 w-20">Guide Vol</span>
+          <input
+            type="range"
+            min={0}
+            max={200}
+            value={guideVolume}
+            onChange={e => setGuideVolume(Number(e.target.value))}
+            className="w-36 h-1 accent-teal-500"
+          />
+          <span className="text-xs text-teal-300 font-mono w-10 text-right">{guideVolume}%</span>
         </label>
 
         <button

--- a/src/components/PitchDefender/NoteTutor.tsx
+++ b/src/components/PitchDefender/NoteTutor.tsx
@@ -32,7 +32,7 @@ import {
 } from './engine/masteryQueue'
 import { ActivePool } from './engine/types'
 import { usePitchDetection } from './usePitchDetection'
-import { initAudio, loadPianoSamples, playPianoNote, playSfx } from './audioEngine'
+import { initAudio, loadPianoSamples, playPianoNote, playSfx, setPianoVolume } from './audioEngine'
 import { noteToFreq, octaveFoldedCents } from './pitchMath'
 
 // ─── Constants ──────────────────────────────────────────────────────────────
@@ -327,6 +327,7 @@ export default function NoteTutor() {
   const [lockProgress, setLockProgress] = useState(0)
   const [expandedNote, setExpandedNote] = useState<string | null>(null)
   const [gateClearedBanner, setGateClearedBanner] = useState(false)
+  const [guideVolume, setGuideVolume] = useState(100)
 
   const processingRef = useRef(false)
   const lockStartRef = useRef(0)
@@ -347,6 +348,8 @@ export default function NoteTutor() {
   // Mic only activates in sing mode
   const { isListening, pitch, startListening, stopListening, pitchRef } =
     usePitchDetection({ noiseGateDb: -45 })
+
+  useEffect(() => { setPianoVolume(guideVolume) }, [guideVolume])
 
   // ─── Load persisted ─────────────────────────────────────────────────────
   useEffect(() => {
@@ -854,6 +857,18 @@ export default function NoteTutor() {
           </span>
         </label>
 
+        <label className="flex items-center gap-3 mb-4">
+          <span className="text-xs text-gray-500 w-20">Guide Vol</span>
+          <input
+            type="range"
+            min={0}
+            max={200}
+            value={guideVolume}
+            onChange={e => setGuideVolume(Number(e.target.value))}
+            className="w-36 h-1 accent-purple-500"
+          />
+          <span className="text-xs text-purple-300 font-mono w-10 text-right">{guideVolume}%</span>
+        </label>
 
         <button onClick={startSession}
           className="px-10 py-4 rounded-2xl text-xl font-bold text-white transition-all active:scale-95 mt-2"

--- a/src/components/PitchDefender/PitchDefender.tsx
+++ b/src/components/PitchDefender/PitchDefender.tsx
@@ -23,7 +23,7 @@ import { noteToFreq, octaveFoldedCents } from './pitchMath'
 import ParentSettings, { DEFAULT_SETTINGS, type GameSettings } from './ParentSettings'
 import {
   initAudio, playSfx as _sfx, loadPianoSamples as _loadSamples,
-  playPianoNote, startMusic, stopMusic, changeMusic, setMicActive,
+  playPianoNote, startMusic, stopMusic, changeMusic, setMicActive, setPianoVolume,
 } from './audioEngine'
 import './animations.css'
 
@@ -59,6 +59,7 @@ export default function PitchDefender() {
   const [gameSettings, setGameSettings] = useState<GameSettings>(DEFAULT_SETTINGS)
   const [screenShake, setScreenShake] = useState(false)
   const [lockProgress, setLockProgress] = useState(0)
+  const [cueVolume, setCueVolume] = useState(100)
   const [laser, setLaser] = useState<{ fromX: number; fromY: number; toX: number; toY: number; hue: number } | null>(null)
   const [particles, setParticles] = useState<{ id: number; x: number; y: number; tx: number; ty: number; size: number; hue: number; duration: number }[]>([])
 
@@ -90,6 +91,7 @@ export default function PitchDefender() {
 
   // Mute music when mic is active (prevents speaker→mic feedback in Echo Cannon)
   useEffect(() => { setMicActive(isListening) }, [isListening])
+  useEffect(() => { setPianoVolume(cueVolume) }, [cueVolume])
 
   // ─── Load persisted data ─────────────────────────────────────────────────
   useEffect(() => {
@@ -829,6 +831,19 @@ export default function PitchDefender() {
             </button>
           </div>
 
+          <label className="flex items-center gap-3 mb-6">
+            <span className="text-xs text-gray-500 w-20">Cue Vol</span>
+            <input
+              type="range"
+              min={0}
+              max={200}
+              value={cueVolume}
+              onChange={e => setCueVolume(Number(e.target.value))}
+              className="w-40 h-1 accent-purple-500"
+            />
+            <span className="text-xs text-purple-300 font-mono w-10 text-right">{cueVolume}%</span>
+          </label>
+
           <button
             onClick={startGame}
             className="px-10 py-4 rounded-2xl text-xl font-bold text-white transition-all active:scale-95"
@@ -1048,7 +1063,7 @@ export default function PitchDefender() {
               </a>
               <a
                 href="/pitch-defender/vocal-trainer"
-                title="Diction training. Drag-drop a recording, BasicPitch extracts the melody, then practice in dichotic mode — recorded voice in your LEFT ear, your live mic in your RIGHT ear. Saves every track to the Synthesia library too."
+                title="Diction training. Drag-drop a recording, BasicPitch extracts the melody, then practice with separated reference and live-mic balance. Saves every track to the Synthesia library too."
                 className="px-5 py-2.5 rounded-xl text-sm font-bold transition-all"
                 style={{
                   background: 'rgba(20, 100, 130, 0.25)',
@@ -1370,6 +1385,18 @@ export default function PitchDefender() {
                 >
                   TAP TO REPLAY TARGET
                 </button>
+                <label className="mt-2 flex items-center justify-center gap-2 text-[11px] text-gray-500">
+                  Cue
+                  <input
+                    type="range"
+                    min={0}
+                    max={200}
+                    value={cueVolume}
+                    onChange={e => setCueVolume(Number(e.target.value))}
+                    className="w-28 h-1 accent-purple-500"
+                  />
+                  <span className="text-purple-300 font-mono w-10 text-right">{cueVolume}%</span>
+                </label>
               </div>
             ) : (
               /* ── Note Blaster: tap buttons ── */
@@ -1382,6 +1409,18 @@ export default function PitchDefender() {
                   >
                     TAP TO REPLAY NOTE
                   </button>
+                  <label className="ml-3 inline-flex items-center gap-2 text-[11px] text-gray-500">
+                    Cue
+                    <input
+                      type="range"
+                      min={0}
+                      max={200}
+                      value={cueVolume}
+                      onChange={e => setCueVolume(Number(e.target.value))}
+                      className="w-28 h-1 accent-teal-500"
+                    />
+                    <span className="text-teal-300 font-mono w-10 text-right">{cueVolume}%</span>
+                  </label>
                 </div>
                 <NoteButtons
                   unlockedNotes={state.unlockedNotes}

--- a/src/components/PitchDefender/PitchforksII.tsx
+++ b/src/components/PitchDefender/PitchforksII.tsx
@@ -24,7 +24,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import Link from 'next/link'
 import { PitchFusion, type FusedPitch } from './pitchFusion'
-import { initAudio, playPianoNote } from './audioEngine'
+import { initAudio, playPianoNote, setPianoVolume } from './audioEngine'
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -168,6 +168,7 @@ export default function PitchforksII() {
   const [pitchHint, setPitchHint] = useState<'low' | 'on' | 'high' | null>(null)
   const [assetsReady, setAssetsReady] = useState(false)
   const [assetError, setAssetError] = useState<string | null>(null)
+  const [cueVolume, setCueVolume] = useState(100)
 
   // Asset cache
   const assetsRef = useRef<{
@@ -247,6 +248,7 @@ export default function PitchforksII() {
   // Sync ref → state
   useEffect(() => { phaseRef.current = phase }, [phase])
   useEffect(() => { viewRef.current = view }, [view])
+  useEffect(() => { setPianoVolume(cueVolume) }, [cueVolume])
 
   // ─── Spawn a villager ─────────────────────────────────────────────────────
   const spawnVillager = useCallback(() => {
@@ -789,6 +791,19 @@ export default function PitchforksII() {
           </div>
         )}
       </div>
+
+      <label className="mt-3 flex items-center gap-3 text-[11px] text-gray-400">
+        Cue Vol
+        <input
+          type="range"
+          min={0}
+          max={200}
+          value={cueVolume}
+          onChange={e => setCueVolume(Number(e.target.value))}
+          className="w-36 h-1 accent-cyan-400"
+        />
+        <span className="text-cyan-300 font-mono w-10 text-right">{cueVolume}%</span>
+      </label>
 
       <div className="mt-3 text-[11px] text-gray-500 max-w-md text-center">
         <strong className="text-gray-300">PitchforksII</strong> is the new sprite-based version.

--- a/src/components/PitchDefender/RetroBlaster.tsx
+++ b/src/components/PitchDefender/RetroBlaster.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/lib/fsrs'
 import { INTRO_ORDER, UNLOCK_THRESHOLDS } from './types'
 import { usePitchDetection } from './usePitchDetection'
-import { initAudio, loadPianoSamples, playPianoNote } from './audioEngine'
+import { initAudio, loadPianoSamples, playPianoNote, setPianoVolume } from './audioEngine'
 import { noteToFreq, octaveFoldedCents } from './pitchMath'
 
 // ─── Constants ──────────────────────────────────────────────────────────────
@@ -426,6 +426,7 @@ export default function RetroBlaster() {
   const [phase, setPhase] = useState<Phase>('menu')
   const [inputMode, setInputMode] = useState<InputMode>('click')
   const [difficulty, setDifficulty] = useState<Difficulty>('easy')
+  const [cueVolume, setCueVolume] = useState(100)
   const [displayScore, setDisplayScore] = useState(0)
   const [displayWave, setDisplayWave] = useState(0)
   const [displayCombo, setDisplayCombo] = useState(0)
@@ -435,6 +436,8 @@ export default function RetroBlaster() {
 
   // Mic detection
   const { isListening, startListening, stopListening, pitchRef: livePitchRef } = usePitchDetection({ noiseGateDb: -45 })
+
+  useEffect(() => { setPianoVolume(cueVolume) }, [cueVolume])
   const hitProcessingRef = useRef(false)
   // Pitchforks v1 lock pattern: matchStartRef holds the time the current
   // in-tolerance hold began (ms timestamp from performance.now()), or 0 when
@@ -1287,6 +1290,19 @@ export default function RetroBlaster() {
             : 'Full speed — faster ramp, more aliens, harder formations. No mercy.'}
         </p>
 
+        <label className="flex items-center gap-3 mb-6">
+          <span className="text-[10px] text-gray-500 tracking-wider">CUE VOL</span>
+          <input
+            type="range"
+            min={0}
+            max={200}
+            value={cueVolume}
+            onChange={e => setCueVolume(Number(e.target.value))}
+            className="w-36 h-1 accent-cyan-400"
+          />
+          <span className="text-[10px] text-cyan-300 font-mono w-10 text-right">{cueVolume}%</span>
+        </label>
+
         <button onClick={handleInsertCoin}
           className="px-10 py-3 text-lg font-bold tracking-widest transition-all active:scale-95"
           style={{
@@ -1527,7 +1543,7 @@ export default function RetroBlaster() {
       )}
 
       {/* Replay button + quit */}
-      <div className="mt-3 flex gap-3">
+      <div className="mt-3 flex gap-3 flex-wrap justify-center items-center">
         <button onClick={replayActiveNote}
           className="px-4 py-2 text-xs font-bold tracking-widest active:scale-95 transition-all"
           style={{
@@ -1537,6 +1553,18 @@ export default function RetroBlaster() {
           }}>
           🔊 PLAY NOTE [SPACE]
         </button>
+        <label className="flex items-center gap-2 px-3 py-2 border border-cyan-900/70 text-[10px] tracking-wider text-gray-400">
+          CUE
+          <input
+            type="range"
+            min={0}
+            max={200}
+            value={cueVolume}
+            onChange={e => setCueVolume(Number(e.target.value))}
+            className="w-28 h-1 accent-cyan-400"
+          />
+          <span className="text-cyan-300 font-mono w-10 text-right">{cueVolume}%</span>
+        </label>
         <button onClick={() => {
           if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = 0 }
           if (inputMode === 'mic') stopListening()

--- a/src/components/PitchDefender/SightReading.tsx
+++ b/src/components/PitchDefender/SightReading.tsx
@@ -19,7 +19,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { NOTE_COLORS } from '@/lib/fsrs'
 import { PitchFusion, type FusedPitch } from './pitchFusion'
-import { initAudio, playPianoNote } from './audioEngine'
+import { initAudio, playPianoNote, markToneEmitted, setPianoVolume } from './audioEngine'
 import { computeLayout, renderStaff, drawNoteHeadWithStem, staffPositionToY, type StaffLayout } from './staffRenderer'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -132,13 +132,15 @@ function generatePhrase(
 // ─── Guide Audio ────────────────────────────────────────────────────────────
 
 let _sightCtx: AudioContext | null = null
-function playTone(semi: number, durationMs: number) {
+function playTone(semi: number, durationMs: number, volumePct = 100) {
   if (!_sightCtx) _sightCtx = new AudioContext()
   const ctx = _sightCtx
   if (ctx.state === 'suspended') ctx.resume()
   const now = ctx.currentTime
   const freq = semiToFreq(semi)
   const dur = durationMs / 1000
+  const volume = Math.max(0, Math.min(2, volumePct / 100))
+  markToneEmitted(durationMs + 100)
 
   const osc = ctx.createOscillator()
   osc.type = 'triangle'
@@ -146,8 +148,8 @@ function playTone(semi: number, durationMs: number) {
 
   const gain = ctx.createGain()
   gain.gain.setValueAtTime(0, now)
-  gain.gain.linearRampToValueAtTime(0.15, now + 0.02)
-  gain.gain.setValueAtTime(0.12, now + dur * 0.7)
+  gain.gain.linearRampToValueAtTime(0.15 * volume, now + 0.02)
+  gain.gain.setValueAtTime(0.12 * volume, now + dur * 0.7)
   gain.gain.exponentialRampToValueAtTime(0.001, now + dur)
 
   osc.connect(gain)
@@ -166,6 +168,7 @@ export default function SightReading() {
   const [difficulty, setDifficulty] = useState<Difficulty>('easy')
   const [phraseLength, setPhraseLength] = useState(8)
   const [mode, setMode] = useState<'pause' | 'flow'>('pause')
+  const [guideVolume, setGuideVolume] = useState(100)
 
   const [phrase, setPhrase] = useState<PhraseNote[]>([])
   const [currentIdx, setCurrentIdx] = useState(0)
@@ -187,6 +190,7 @@ export default function SightReading() {
   useEffect(() => { phraseRef.current = phrase }, [phrase])
   useEffect(() => { currentIdxRef.current = currentIdx }, [currentIdx])
   useEffect(() => { statsRef.current = stats }, [stats])
+  useEffect(() => { setPianoVolume(guideVolume) }, [guideVolume])
 
   // Canvas layout
   const updateLayout = useCallback(() => {
@@ -226,7 +230,7 @@ export default function SightReading() {
     // Play the starting note as reference
     const first = phraseRef.current[0]
     if (first) {
-      playTone(first.semitones, 1500)
+      playTone(first.semitones, 1500, guideVolume)
       // Also play via piano for familiarity
       const name = first.name
       if (!name.includes('#') && !name.includes('b')) {
@@ -347,9 +351,9 @@ export default function SightReading() {
 
     // Play hint on easy difficulty
     if (difficulty === 'easy') {
-      playTone(notes[nextIdx].semitones, 400)
+      playTone(notes[nextIdx].semitones, 400, guideVolume)
     }
-  }, [difficulty])
+  }, [difficulty, guideVolume])
 
   // ─── Render Frame (staff + notes) ─────────────────────────────────────
   const renderFrame = useCallback(() => {
@@ -563,6 +567,19 @@ export default function SightReading() {
           </div>
         </div>
 
+        <label className="flex items-center gap-3 mb-6">
+          <span className="text-xs text-gray-500 w-20">Guide Vol</span>
+          <input
+            type="range"
+            min={0}
+            max={200}
+            value={guideVolume}
+            onChange={e => setGuideVolume(Number(e.target.value))}
+            className="w-40 h-1 accent-yellow-500"
+          />
+          <span className="text-xs text-yellow-300 font-mono w-10 text-right">{guideVolume}%</span>
+        </label>
+
         <button onClick={generateNewPhrase}
           className="px-10 py-4 rounded-2xl text-xl font-bold text-white transition-all active:scale-95"
           style={{
@@ -597,9 +614,21 @@ export default function SightReading() {
             <div className="text-sm text-gray-500 mb-2">
               Starting note: <span className="text-yellow-400 font-bold">{phrase[0]?.name}</span>
             </div>
+            <label className="flex items-center justify-center gap-3 mb-4">
+              <span className="text-xs text-gray-500">Guide Vol</span>
+              <input
+                type="range"
+                min={0}
+                max={200}
+                value={guideVolume}
+                onChange={e => setGuideVolume(Number(e.target.value))}
+                className="w-36 h-1 accent-yellow-500"
+              />
+              <span className="text-xs text-yellow-300 font-mono w-10 text-right">{guideVolume}%</span>
+            </label>
             <div className="flex gap-3">
               <button onClick={() => {
-                if (phrase[0]) playTone(phrase[0].semitones, 1500)
+                if (phrase[0]) playTone(phrase[0].semitones, 1500, guideVolume)
               }}
                 className="px-4 py-2 rounded-xl text-sm text-gray-400 border border-gray-700 active:scale-95 transition-all">
                 🔊 Hear Starting Note

--- a/src/components/PitchDefender/VocalTrainerIII.tsx
+++ b/src/components/PitchDefender/VocalTrainerIII.tsx
@@ -7,7 +7,7 @@
 // V3 = V1 plus the mixing desk (built for Music Man barbershop part practice):
 //   • Per-stream L/R BALANCE sliders — pan no longer hardcoded; defaults match
 //     V1 (vocals -0.7 / music 0 / mic +1)
-//   • Volume range 0-400% per stream through a master brick-wall limiter
+//   • Volume range 0-200% per stream through a master brick-wall limiter
 //     (DynamicsCompressorNode) so "blast" gets LOUD instead of clipping harshly
 //   • Live level METERS per stream (post-gain) — visual proof the sliders work
 //   • AudioContext always latencyHint:'interactive' — V1's default 'usb' profile
@@ -282,7 +282,7 @@ const MIC_PROFILES: Record<MicProfile, { label: string; gain: number; agc: boole
 
 const IS_MOBILE = typeof navigator !== 'undefined' && /Android|iPhone|iPad|Mobile/i.test(navigator.userAgent);
 
-const VOL_MAX = 400; // V3: percent ceiling per stream (V1 was 200)
+const VOL_MAX = 200; // issue #22: shared 0-200% ceiling per stream
 const PLUNK_DEFAULT_VOL = 180;
 const PLUNK_GAIN_SCALE = 0.55;
 const PLUNK_LOOKAHEAD_SECONDS = 0.45;
@@ -809,10 +809,10 @@ export default function VocalTrainerIII() {
   const [micEnabled, setMicEnabled] = useState(false);
   const [plunkEnabled, setPlunkEnabled] = useState(false); // V3.7: OFF by default — plunk is opt-in (Jon 2026-06-27)
   const [plunkVol, setPlunkVol] = useState(PLUNK_DEFAULT_VOL);
-  // V3: per-stream balance (-1 hard-left … +1 hard-right). Defaults = V1's fixed pans.
+  // V3: per-stream balance (-1 left ... +1 right). Defaults avoid edge pan.
   const [vocalPan, setVocalPan] = useState(-0.7);
   const [musicPan, setMusicPan] = useState(0);
-  const [micPan, setMicPan] = useState(1);
+  const [micPan, setMicPan] = useState(0.7);
   // V3: seek bar + A/B loop state. durationSec mirrors playbackDurationRef for UI.
   const [durationSec, setDurationSec] = useState(0);
   const [loopA, setLoopA] = useState<number | null>(null);
@@ -837,7 +837,7 @@ export default function VocalTrainerIII() {
 
   const audioCtxRef = useRef<AudioContext | null>(null);
 
-  // Vocal chain (hard-left)
+  // Vocal chain (default -0.7 left)
   const vocalGainNodeRef = useRef<GainNode | null>(null);
   const vocalPanNodeRef = useRef<StereoPannerNode | null>(null);
   const vocalSourceRef = useRef<AudioBufferSourceNode | null>(null);
@@ -907,7 +907,7 @@ export default function VocalTrainerIII() {
   // V3: pan mirrors for the same stable-callback reason.
   const vocalPanRef = useRef(-0.7);
   const musicPanRef = useRef(0);
-  const micPanRef = useRef(1);
+  const micPanRef = useRef(0.7);
   useEffect(() => { vocalPanRef.current = vocalPan; }, [vocalPan]);
   useEffect(() => { musicPanRef.current = musicPan; }, [musicPan]);
   useEffect(() => { micPanRef.current = micPan; }, [micPan]);
@@ -1932,7 +1932,7 @@ export default function VocalTrainerIII() {
       const analyser = ctx.createAnalyser();
       analyser.fftSize = 256;
       const pan = ctx.createStereoPanner();
-      pan.pan.value = micPanRef.current; // V3: user-adjustable balance (default hard-right)
+      pan.pan.value = micPanRef.current; // V3: user-adjustable balance (default +0.7)
       src.connect(profileGain).connect(userGain).connect(analyser).connect(pan).connect(limiterRef.current!);
       // V3.2: 2048-fft leaf tap off the RAW mic source for live voice-pitch
       // detection — same stream Jon hears (so it's proven live), independent of
@@ -2609,13 +2609,13 @@ export default function VocalTrainerIII() {
               <span className="font-semibold text-gray-100">Load your song.</span> Drag your practice track (like a Music Man plunk track .m4a) into the upload box below — or pick one already saved in the Library at the top.
             </li>
             <li>
-              <span className="font-semibold text-gray-100">Click &ldquo;Start mic monitor.&rdquo;</span> Allow the microphone when the browser asks. Now sing — you should hear your own voice in your RIGHT ear instantly. If it feels delayed, refresh the page and start the mic before playing the track. On a phone, the <span className="text-cyan-300">Phone mic (auto-boost)</span> profile is selected automatically — if your voice is still soft, push the Mic volume slider up and watch its meter.
+              <span className="font-semibold text-gray-100">Click &ldquo;Start mic monitor.&rdquo;</span> Allow the microphone when the browser asks. Now sing — you should hear your own voice slightly right of center instantly. If it feels delayed, refresh the page and start the mic before playing the track. On a phone, the <span className="text-cyan-300">Phone mic (auto-boost)</span> profile is selected automatically — if your voice is still soft, push the Mic volume slider up and watch its meter.
             </li>
             <li>
-              <span className="font-semibold text-gray-100">Press Play.</span> The track plays mostly in your LEFT ear, your live voice stays in your RIGHT ear. The moving cursor follows the notes.
+              <span className="font-semibold text-gray-100">Press Play.</span> The track plays mostly in your left ear, your live voice stays slightly right. The moving cursor follows the notes.
             </li>
             <li>
-              <span className="font-semibold text-gray-100">Mix it your way.</span> Each channel has a <span className="text-amber-300">volume slider (0–400%)</span>, a <span className="text-cyan-300">balance slider (L ↔ R)</span>, and a <span className="text-green-400">green level meter</span> that dances when sound is flowing. Want to BLAST your own voice? Push Mic volume up and watch its meter respond. Want the track louder? Blast Vocals and pull Mic down. The meters are your proof — if a meter moves, that channel is live.
+              <span className="font-semibold text-gray-100">Mix it your way.</span> Each channel has a <span className="text-amber-300">volume slider (0–200%)</span>, a <span className="text-cyan-300">balance slider (L ↔ R)</span>, and a <span className="text-green-400">green level meter</span> that dances when sound is flowing. Want your voice louder? Push Mic volume up and watch its meter respond. Want the track louder? Raise Vocals and pull Mic down. The meters are your proof — if a meter moves, that channel is live.
             </li>
             <li>
               <span className="font-semibold text-gray-100">Drill the hard spots.</span> Pause, drag the playhead back, repeat the phrase until it locks in. Small loops beat full run-throughs.


### PR DESCRIPTION
Linked worklist issue: jonchyatt/codex-worklist#22
Related meter-parity PR: https://github.com/jonchyatt/resetbiology/pull/13

## Summary
- Added live 0-200% guide/cue volume sliders to `DrillMode`, `NoteTutor`, `SightReading`, `RetroBlaster`, `PitchforksII`, and the main `PitchDefender` shell.
- Upgraded `ChoirPractice` guide/self-feedback audio controls: guide is now 0-200%, self-feedback has a dedicated 0-200% live `GainNode` slider, and custom guide tones mark the echo-suppression window.
- Normalized `VocalTrainerIII` mixer to issue #22's 0-200% stream ceiling and moved the default live-mic balance from hard-right to +0.7.
- Did not touch the pitch stack files: `audioEngine.ts`, `crepeDetector.ts`, `pestoDetector.ts`, `pitchFusion.ts`.
- Did not edit active daily-use originals `VocalTrainer.tsx` or `VocalTrainerII.tsx` in place.

## Audit checklist
| Game/file | Mic starts | Gate | Octave-flex | Echo suppression | Heard meter | Per-stream sliders |
| --- | --- | --- | --- | --- | --- | --- |
| `Pitchforks.tsx` | PASS | PASS | PASS | PASS via `playPianoNote`/`markToneEmitted` | PASS canonical | N/A: no reference/monitor stream |
| `PitchforksII.tsx` | PASS | PASS | PASS | PASS via `playPianoNote` | Pending full meter parity in PR #13 | PASS cue 0-200 live |
| `PitchforksIII.tsx` | PASS | PASS | PASS | PASS | PASS | PASS cue 0-200 existing |
| `RetroBlaster.tsx` | PASS | PASS | PASS | PASS via `playPianoNote` | PASS existing v1 overlay | PASS cue/replay 0-200 live |
| `PitchDefender.tsx` | PASS | PASS | PASS | PASS via `playPianoNote` | Pending full meter parity in PR #13 | PASS cue/replay 0-200 live |
| `DrillMode.tsx` | PASS | PASS | PASS | PASS via `playPianoNote` | PASS existing v1 bar, cleanup in PR #13 | PASS guide 0-200 live |
| `NoteTutor.tsx` | PASS | PASS | PASS | PASS via `playPianoNote` | PASS existing v1 bar, cleanup in PR #13 | PASS guide 0-200 live |
| `NoteRunner.tsx` | PASS | PASS | PASS | PASS via `playPianoNote` | Pending full meter parity in PR #13 | PASS plunk 0-200 existing |
| `SynthesiaRunner.tsx` | PASS | PASS | PASS | PASS via `playPianoNote` | Pending full meter parity in PR #13 | PASS plunk 0-200 existing |
| `SimplySing.tsx` | PASS | PASS | PASS | PASS via `markToneEmitted` | Added in PR #13 | PASS plunk 0-200 existing |
| `ChoirPractice.tsx` | PASS | PASS | PASS | PASS: custom guide now calls `markToneEmitted` | PASS existing v1 bar, cleanup in PR #13 | PASS guide + self-feedback 0-200 live |
| `SightReading.tsx` | PASS | PASS | PASS | PASS: custom guide now calls `markToneEmitted` | PASS existing v1 bar, cleanup in PR #13 | PASS guide 0-200 live |
| `VocalTrainer.tsx` | PASS | PASS | PASS | PASS | PASS | PASS existing 0-200; active-use original not edited |
| `VocalTrainerII.tsx` | PASS | PASS | PASS | Existing | PASS | Active-use original not edited |
| `VocalTrainerIII.tsx` | PASS | PASS via monitor stream | PASS | PASS | PASS | PASS normalized to 0-200 and default mic pan +0.7 |
| `LyricsTrainer.tsx` | N/A speech-recognition trainer | N/A | N/A | N/A | N/A | N/A |
| Diagnostics/utilities | N/A | N/A | N/A | N/A | N/A | N/A |

## Visual/described proof
- DrillMode menu now renders `Guide Vol 100%` beside a 0-200 range slider; its existing mic-lock bar remains the heard-feedback meter.
- RetroBlaster menu and in-game replay controls now render `CUE VOL/CUE 100%` sliders; its existing v1 vocal-feedback overlay remains below the canvas in mic mode.
- SightReading setup/ready screens now expose `Guide Vol 100%` and route custom guide tones through live 0-200% gain plus tone suppression.
- ChoirPractice setup code now exposes both guide and voice 0-200 controls; guide is a custom synth and voice monitor updates its existing `GainNode` without restarting playback.

## Verification
- `npx tsc --noEmit`
- `npm run build` (passes; existing Auth0/env and Next workspace-root warnings remain)
- Focused source scan over touched files returned no matches for `0-400`, `0?400`, `hard-right`, `hard right`, `RIGHT ear`, `pan.value = 1`, or same-line `max=100` range inputs.
- Chrome smoke checks against local dev server returned 200/no error screen for `/pitch-defender/drill`, `/pitch-defender/note-tutor`, `/pitch-defender/sight-reading`, `/pitch-defender/retro`, `/pitch-defender/pitchforks-2`, `/pitch-defender`, and `/pitch-defender/vocal-trainer-3`. Visible slider text was confirmed on the changed direct-entry screens above.

## Notes
- This PR intentionally does not restack the full meter-parity diff from PR #13. Once PR #13 lands, the heard-meter column becomes the shared Pitchforks-v1 implementation everywhere.
