### PR TITLE
[worklist#21] RB Portal: cross-device Auth0 score persistence for pitch-defender games

### DIFF
--- a/app/api/pitch-scores/route.ts
+++ b/app/api/pitch-scores/route.ts
@@ -1,0 +1,253 @@
+import { NextResponse } from 'next/server'
+import type { Prisma } from '@prisma/client'
+import { auth0 } from '@/lib/auth0'
+import { prisma } from '@/lib/prisma'
+
+export const dynamic = 'force-dynamic'
+
+type IncomingScore = {
+  gameKey: string
+  payload: Prisma.InputJsonValue
+  updatedAt: Date
+}
+
+function errorResponse(message: string, status: number) {
+  return NextResponse.json({ error: message }, { status })
+}
+
+function parseUpdatedAt(value: unknown): Date | null {
+  if (typeof value !== 'string' && typeof value !== 'number') return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function parseJsonPayload(value: unknown): Prisma.InputJsonValue | null {
+  if (value === null || value === undefined) return null
+  try {
+    JSON.stringify(value)
+  } catch {
+    return null
+  }
+  return value as Prisma.InputJsonValue
+}
+
+function normalizeScores(body: unknown): IncomingScore[] | { error: string } {
+  if (!body || typeof body !== 'object') return { error: 'Request body required' }
+
+  const raw = body as {
+    gameKey?: unknown
+    payload?: unknown
+    updatedAt?: unknown
+    scores?: unknown
+  }
+
+  const source = raw.scores === undefined
+    ? [{ gameKey: raw.gameKey, payload: raw.payload, updatedAt: raw.updatedAt }]
+    : Array.isArray(raw.scores)
+      ? raw.scores
+      : Object.entries(raw.scores && typeof raw.scores === 'object' ? raw.scores : {})
+          .map(([gameKey, value]) => ({
+            gameKey,
+            payload: value && typeof value === 'object' && 'payload' in value
+              ? (value as { payload: unknown }).payload
+              : value,
+            updatedAt: value && typeof value === 'object' && 'updatedAt' in value
+              ? (value as { updatedAt: unknown }).updatedAt
+              : undefined,
+          }))
+
+  const normalized: IncomingScore[] = []
+  for (const item of source) {
+    if (!item || typeof item !== 'object') return { error: 'Each score must be an object' }
+    const score = item as { gameKey?: unknown; payload?: unknown; updatedAt?: unknown }
+    if (typeof score.gameKey !== 'string' || score.gameKey.trim().length === 0) {
+      return { error: 'Each score requires a gameKey' }
+    }
+    if (score.gameKey.length > 160) return { error: 'gameKey is too long' }
+    const payload = parseJsonPayload(score.payload)
+    if (payload === null) return { error: 'Each score requires a JSON payload' }
+    const updatedAt = parseUpdatedAt(score.updatedAt)
+    if (!updatedAt) return { error: 'Each score requires a valid updatedAt' }
+    normalized.push({
+      gameKey: score.gameKey,
+      payload,
+      updatedAt,
+    })
+  }
+
+  if (normalized.length === 0) return { error: 'At least one score is required' }
+  if (normalized.length > 100) return { error: 'Too many scores in one request' }
+  return normalized
+}
+
+async function resolveUser() {
+  const session = await auth0.getSession()
+
+  if (!session?.user?.sub) {
+    return null
+  }
+
+  let user = await prisma.user.findUnique({
+    where: { auth0Sub: session.user.sub },
+  })
+
+  if (!user && session.user.email) {
+    user = await prisma.user.findUnique({
+      where: { email: session.user.email },
+    })
+
+    if (user) {
+      user = await prisma.user.update({
+        where: { id: user.id },
+        data: { auth0Sub: session.user.sub },
+      })
+    }
+  }
+
+  if (!user) {
+    user = await prisma.user.create({
+      data: {
+        auth0Sub: session.user.sub,
+        email: session.user.email ?? null,
+        name: session.user.name ?? null,
+        image: session.user.picture ?? null,
+      },
+    })
+  }
+
+  return user
+}
+
+async function writeScore(userId: string, score: IncomingScore) {
+  const existing = await prisma.gameScore.findUnique({
+    where: {
+      userId_gameKey: {
+        userId,
+        gameKey: score.gameKey,
+      },
+    },
+  })
+
+  if (existing && existing.localUpdatedAt > score.updatedAt) {
+    return existing
+  }
+
+  if (existing) {
+    return prisma.gameScore.update({
+      where: { id: existing.id },
+      data: {
+        payload: score.payload,
+        localUpdatedAt: score.updatedAt,
+      },
+    })
+  }
+
+  try {
+    return await prisma.gameScore.create({
+      data: {
+        userId,
+        gameKey: score.gameKey,
+        payload: score.payload,
+        localUpdatedAt: score.updatedAt,
+      },
+    })
+  } catch (error) {
+    if (typeof error === 'object' && error && 'code' in error && error.code === 'P2002') {
+      return prisma.gameScore.update({
+        where: {
+          userId_gameKey: {
+            userId,
+            gameKey: score.gameKey,
+          },
+        },
+        data: {
+          payload: score.payload,
+          localUpdatedAt: score.updatedAt,
+        },
+      })
+    }
+    throw error
+  }
+}
+
+export async function GET() {
+  try {
+    const user = await resolveUser()
+    if (!user) return errorResponse('Unauthorized', 401)
+
+    const rows = await prisma.gameScore.findMany({
+      where: { userId: user.id },
+      orderBy: { updatedAt: 'desc' },
+    })
+
+    const scores = Object.fromEntries(rows.map(row => [
+      row.gameKey,
+      {
+        payload: row.payload,
+        updatedAt: row.localUpdatedAt.toISOString(),
+        serverUpdatedAt: row.updatedAt.toISOString(),
+      },
+    ]))
+
+    return NextResponse.json({ success: true, scores })
+  } catch (error) {
+    console.error('GET /api/pitch-scores error:', error)
+    return errorResponse('Failed to load pitch scores', 500)
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const user = await resolveUser()
+    if (!user) return errorResponse('Unauthorized', 401)
+
+    const normalized = normalizeScores(await request.json())
+    if ('error' in normalized) return errorResponse(normalized.error, 400)
+
+    const rows = []
+    for (const score of normalized) {
+      rows.push(await writeScore(user.id, score))
+    }
+
+    return NextResponse.json({
+      success: true,
+      scores: Object.fromEntries(rows.map(row => [
+        row.gameKey,
+        {
+          payload: row.payload,
+          updatedAt: row.localUpdatedAt.toISOString(),
+          serverUpdatedAt: row.updatedAt.toISOString(),
+        },
+      ])),
+    })
+  } catch (error) {
+    console.error('POST /api/pitch-scores error:', error)
+    return errorResponse('Failed to save pitch scores', 500)
+  }
+}
+
+export const PUT = POST
+
+export async function DELETE(request: Request) {
+  try {
+    const user = await resolveUser()
+    if (!user) return errorResponse('Unauthorized', 401)
+
+    const body = await request.json() as { gameKey?: unknown }
+    if (typeof body.gameKey !== 'string' || body.gameKey.trim().length === 0) {
+      return errorResponse('gameKey required', 400)
+    }
+
+    await prisma.gameScore.deleteMany({
+      where: {
+        userId: user.id,
+        gameKey: body.gameKey,
+      },
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('DELETE /api/pitch-scores error:', error)
+    return errorResponse('Failed to delete pitch score', 500)
+  }
+}

--- a/prisma/migrations/20260703004500_add_pitch_defender_game_scores/README.md
+++ b/prisma/migrations/20260703004500_add_pitch_defender_game_scores/README.md
@@ -1,0 +1,16 @@
+# add_pitch_defender_game_scores
+
+This repository uses Prisma with MongoDB, so Prisma Migrate does not emit SQL migration files.
+
+Deploy step:
+
+```powershell
+npx prisma db push
+npx prisma generate
+```
+
+Schema change:
+
+- Adds `GameScore`, mapped to the `game_scores` collection.
+- Adds `User.gameScores`.
+- Adds a unique user/game key on `[userId, gameKey]`.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,7 @@ model User {
   scheduledNotifications  ScheduledNotification[]
   pushSubscriptions       PushSubscription[]
   pushSubscriptionHealth  PushSubscriptionHealth[]
+  gameScores              GameScore[]
   visionSessions          VisionSession[]
   visionProgress          VisionProgress[]
   nbackSessions           NBackSession[]
@@ -845,6 +846,21 @@ model VoiceUsageLog {
   user      User     @relation(fields: [userId], references: [id])
 
   @@map("voice_usage_logs")
+}
+
+model GameScore {
+  id             String   @id @default(auto()) @map("_id") @db.ObjectId
+  userId         String   @db.ObjectId
+  gameKey        String
+  payload        Json
+  localUpdatedAt DateTime
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  user           User     @relation(fields: [userId], references: [id])
+
+  @@unique([userId, gameKey], name: "userId_gameKey")
+  @@index([userId, updatedAt])
+  @@map("game_scores")
 }
 
 // --- INVENTORY & BUNDLE MANAGEMENT ---

--- a/src/components/PitchDefender/ChoirPractice.tsx
+++ b/src/components/PitchDefender/ChoirPractice.tsx
@@ -25,6 +25,7 @@ import { NOTE_COLORS } from '@/lib/fsrs'
 import { PitchFusion, type FusedPitch, DEFAULT_FUSION_CONFIG } from './pitchFusion'
 import { initAudio, playPianoNote } from './audioEngine'
 import { extractMelodyFromComposition, compositionHasNotes } from './composerExtract'
+import { usePitchScoreSync } from './scoreSync'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -356,7 +357,7 @@ export default function ChoirPractice() {
   // Uses the shared composerExtract module — handles BOTH the new measures
   // format AND the legacy flat-notes fallback. Previous reader only checked
   // c.notes (legacy) and silently dropped every modern Composer save.
-  useEffect(() => {
+  const refreshComposedList = useCallback(() => {
     if (phase !== 'upload') return
     try {
       const out: { key: string; title: string; noteCount: number }[] = []
@@ -376,6 +377,12 @@ export default function ChoirPractice() {
       setComposedList(out)
     } catch {}
   }, [phase])
+  usePitchScoreSync({
+    keys: [],
+    includeCompositions: true,
+    onHydrate: refreshComposedList,
+  })
+  useEffect(() => { refreshComposedList() }, [refreshComposedList])
 
   // Load a composition from localStorage as if it were a sample score
   const loadComposition = useCallback((storageKey: string) => {

--- a/src/components/PitchDefender/Composer.tsx
+++ b/src/components/PitchDefender/Composer.tsx
@@ -46,6 +46,7 @@ const {
   StaveConnector, Curve, StaveHairpin,
 } = VF
 import { initAudio, playPianoNote, loadPianoSamples } from './audioEngine'
+import { removePitchScore, savePitchScore, usePitchScoreSync } from './scoreSync'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -386,6 +387,11 @@ export default function Composer() {
     list.sort((a, b) => (b.comp.savedAt || '').localeCompare(a.comp.savedAt || ''))
     setSavedList(list)
   }, [])
+  usePitchScoreSync({
+    keys: [],
+    includeCompositions: true,
+    onHydrate: () => refreshSavedList(),
+  })
   useEffect(() => { refreshSavedList() }, [refreshSavedList])
 
   // ─── Begin composing (transition from setup → editing) ────────────────────
@@ -469,7 +475,7 @@ export default function Composer() {
 
   const deleteSavedComposition = useCallback((key: string, title: string) => {
     if (!confirm(`Delete "${title}"?`)) return
-    localStorage.removeItem(key)
+    removePitchScore(key)
     refreshSavedList()
   }, [refreshSavedList])
 
@@ -479,7 +485,7 @@ export default function Composer() {
     const c = { ...comp, savedAt: new Date().toISOString() }
     const key = STORAGE_PREFIX + slugify(c.title)
     try {
-      localStorage.setItem(key, JSON.stringify(c))
+      savePitchScore(key, c, { updatedAt: c.savedAt })
       setStatusMsg(`Saved "${c.title}" — available in all Pitch Defender games`)
       setComp(c)
       refreshSavedList()

--- a/src/components/PitchDefender/DrillMode.tsx
+++ b/src/components/PitchDefender/DrillMode.tsx
@@ -22,6 +22,7 @@ import PitchGuidance from './PitchGuidance'
 import { usePitchDetection } from './usePitchDetection'
 import { initAudio, loadPianoSamples, playPianoNote } from './audioEngine'
 import { noteToFreq, octaveFoldedCents, PITCH_ON_TOLERANCE_CENTS } from './pitchMath'
+import { savePitchScore, usePitchScoreSync } from './scoreSync'
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -80,6 +81,21 @@ export default function DrillMode() {
 
   // Pitch detection for mic mode
   const { isListening, pitch, startListening, stopListening, pitchRef: livePitchRef } = usePitchDetection({ noiseGateDb: -45 })
+
+  usePitchScoreSync({
+    keys: [FSRS_KEY, DRILL_PROGRESS_KEY],
+    onHydrate: (scores) => {
+      const fsrs = scores[FSRS_KEY]?.payload
+      if (fsrs && typeof fsrs === 'object' && !Array.isArray(fsrs)) {
+        fsrsRef.current = fsrs as Record<string, NoteMemory>
+      }
+
+      const progress = scores[DRILL_PROGRESS_KEY]?.payload
+      if (progress && typeof progress === 'object' && !Array.isArray(progress)) {
+        progressRef.current = progress as DrillProgress
+      }
+    },
+  })
 
   // Keep refs in sync with state
   useEffect(() => { sessionStatsRef.current = sessionStats }, [sessionStats])
@@ -142,11 +158,11 @@ export default function DrillMode() {
 
   // ─── Persist ──────────────────────────────────────────────────────────
   const saveFsrs = useCallback(() => {
-    try { localStorage.setItem(FSRS_KEY, JSON.stringify(fsrsRef.current)) } catch {}
+    savePitchScore(FSRS_KEY, fsrsRef.current)
   }, [])
 
   const saveProgress = useCallback(() => {
-    try { localStorage.setItem(DRILL_PROGRESS_KEY, JSON.stringify(progressRef.current)) } catch {}
+    savePitchScore(DRILL_PROGRESS_KEY, progressRef.current)
   }, [])
 
   // ─── Mic tick — Pitchforks v1 pattern (THE canonical reference) ──

--- a/src/components/PitchDefender/LyricsTrainer.tsx
+++ b/src/components/PitchDefender/LyricsTrainer.tsx
@@ -16,6 +16,7 @@ import {
   gradeSpan, canAdvance, advance, advanceHalf, completeLine,
   lineId, transId, knownRange, lineText, isPartial,
 } from './engine/backwardChain'
+import { savePitchScore, usePitchScoreSync } from './scoreSync'
 
 const STORAGE_KEY = 'lt_v1_state'
 
@@ -342,6 +343,20 @@ export default function LyricsTrainer() {
   // from the phone's remote-devtools session.
   const debugRef = useRef(false)
 
+  usePitchScoreSync({
+    keys: [STORAGE_KEY],
+    onHydrate: (scores) => {
+      const payload = scores[STORAGE_KEY]?.payload
+      if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return
+      const parsed = payload as Persisted
+      if (parsed.monologue) {
+        if (!parsed.monologue.partialStart) parsed.monologue.partialStart = {}
+        if (typeof parsed.monologue.rampRemaining !== 'number') parsed.monologue.rampRemaining = 0
+      }
+      setState(parsed)
+    },
+  })
+
   // ─── Persistence ────────────────────────────────────────────────────────
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -361,7 +376,7 @@ export default function LyricsTrainer() {
 
   const persist = useCallback((s: Persisted) => {
     if (typeof window === 'undefined') return
-    try { window.localStorage.setItem(STORAGE_KEY, JSON.stringify(s)) }
+    try { savePitchScore(STORAGE_KEY, s) }
     catch { /* quota */ }
   }, [])
 

--- a/src/components/PitchDefender/NoteEntry.tsx
+++ b/src/components/PitchDefender/NoteEntry.tsx
@@ -14,6 +14,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { NOTE_COLORS } from '@/lib/fsrs'
 import { initAudio, playPianoNote, loadPianoSamples } from './audioEngine'
+import { savePitchScore, usePitchScoreSync } from './scoreSync'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -50,6 +51,16 @@ export default function NoteEntry() {
   const [showSaved, setShowSaved] = useState(false)
   const [lastTapped, setLastTapped] = useState<string | null>(null)
   const audioInitRef = useRef(false)
+
+  usePitchScoreSync({
+    keys: [STORAGE_KEY],
+    onHydrate: (scores) => {
+      const payload = scores[STORAGE_KEY]?.payload
+      if (Array.isArray(payload)) {
+        setSavedSongs(payload as { name: string; notes: number[] }[])
+      }
+    },
+  })
 
   // Load saved songs
   useEffect(() => {
@@ -120,14 +131,14 @@ export default function NoteEntry() {
     }
     const updated = [...savedSongs, songData]
     setSavedSongs(updated)
-    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(updated)) } catch {}
+    savePitchScore(STORAGE_KEY, updated)
   }, [notes, songName, savedSongs])
 
   // ─── Delete Saved Song ────────────────────────────────────────────────
   const deleteSong = useCallback((idx: number) => {
     const updated = savedSongs.filter((_, i) => i !== idx)
     setSavedSongs(updated)
-    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(updated)) } catch {}
+    savePitchScore(STORAGE_KEY, updated)
   }, [savedSongs])
 
   // ─── Playback ─────────────────────────────────────────────────────────

--- a/src/components/PitchDefender/NoteRunner.tsx
+++ b/src/components/PitchDefender/NoteRunner.tsx
@@ -19,6 +19,7 @@ import { NOTE_COLORS } from '@/lib/fsrs'
 import { initAudio, playPianoNote, setPianoVolume } from './audioEngine'
 import { extractNotesFromXML, notesToSemitoneArray, type ExtractionResult } from './extractNotes'
 import { extractMelodyFromComposition } from './composerExtract'
+import { usePitchScoreSync } from './scoreSync'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -165,7 +166,7 @@ export default function NoteRunner() {
   // format AND the legacy flat-notes fallback. Previous reader only worked
   // with legacy format and silently dropped every modern Composer save.
   const [composedSongs, setComposedSongs] = useState<{ name: string; notes: number[]; description: string }[]>([])
-  useEffect(() => {
+  const refreshComposedSongs = useCallback(() => {
     try {
       const out: { name: string; notes: number[]; description: string }[] = []
       for (let i = 0; i < localStorage.length; i++) {
@@ -185,6 +186,12 @@ export default function NoteRunner() {
       setComposedSongs(out)
     } catch {}
   }, [])
+  usePitchScoreSync({
+    keys: [],
+    includeCompositions: true,
+    onHydrate: refreshComposedSongs,
+  })
+  useEffect(() => { refreshComposedSongs() }, [refreshComposedSongs])
 
   // Merge built-in + composed + custom songs
   const allSongs = [...SONGS, ...composedSongs, ...customSongs]

--- a/src/components/PitchDefender/NoteTutor.tsx
+++ b/src/components/PitchDefender/NoteTutor.tsx
@@ -34,6 +34,7 @@ import { ActivePool } from './engine/types'
 import { usePitchDetection } from './usePitchDetection'
 import { initAudio, loadPianoSamples, playPianoNote, playSfx } from './audioEngine'
 import { noteToFreq, octaveFoldedCents } from './pitchMath'
+import { removePitchScore, savePitchScore, usePitchScoreSync } from './scoreSync'
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -348,6 +349,19 @@ export default function NoteTutor() {
   const { isListening, pitch, startListening, stopListening, pitchRef } =
     usePitchDetection({ noiseGateDb: -45 })
 
+  usePitchScoreSync({
+    keys: [STORAGE_KEY],
+    onHydrate: (scores) => {
+      const payload = scores[STORAGE_KEY]?.payload
+      if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return
+      const parsed = payload as Partial<Persisted>
+      if (parsed.colorHints === undefined) parsed.colorHints = true
+      if (parsed.noteRamp === undefined) parsed.noteRamp = null
+      setState(ensurePoolForOctave(parsed as Persisted))
+      setMode(parsed.preferredMode ?? 'staff')
+    },
+  })
+
   // ─── Load persisted ─────────────────────────────────────────────────────
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -370,7 +384,7 @@ export default function NoteTutor() {
   const persist = useCallback((s: Persisted) => {
     if (typeof window === 'undefined') return
     try {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(s))
+      savePitchScore(STORAGE_KEY, s)
     } catch { /* quota — drop */ }
   }, [])
 
@@ -735,7 +749,7 @@ export default function NoteTutor() {
   const resetProgress = useCallback(() => {
     if (!confirm('Wipe all Note Tutor progress and start over? Mastery, pool, sequence training, and the color-hints toggle all reset.')) return
     try {
-      if (typeof window !== 'undefined') window.localStorage.removeItem(STORAGE_KEY)
+      if (typeof window !== 'undefined') removePitchScore(STORAGE_KEY)
     } catch { /* quota or private mode */ }
     clearAllTimers()
     processingRef.current = false

--- a/src/components/PitchDefender/PitchDefender.tsx
+++ b/src/components/PitchDefender/PitchDefender.tsx
@@ -25,6 +25,7 @@ import {
   initAudio, playSfx as _sfx, loadPianoSamples as _loadSamples,
   playPianoNote, startMusic, stopMusic, changeMusic, setMicActive,
 } from './audioEngine'
+import { savePitchScore, usePitchScoreSync } from './scoreSync'
 import './animations.css'
 
 export type GameMode = 'noteBlaster' | 'echoCannon' | 'staffDefender' | 'sequenceAssault' | 'intervalHunter' | 'survival'
@@ -85,6 +86,21 @@ export default function PitchDefender() {
   const { isListening, pitch, error: micError, pitchRef: livePitchRef, startListening, stopListening } = usePitchDetection({ noiseGateDb })
   const countdownTimersRef = useRef<ReturnType<typeof setTimeout>[]>([])
 
+  usePitchScoreSync({
+    keys: [FSRS_KEY, PROGRESS_KEY],
+    onHydrate: (scores) => {
+      const fsrs = scores[FSRS_KEY]?.payload
+      if (fsrs && typeof fsrs === 'object' && !Array.isArray(fsrs)) {
+        fsrsRef.current = fsrs as Record<string, NoteMemory>
+      }
+
+      const progress = scores[PROGRESS_KEY]?.payload
+      if (progress && typeof progress === 'object' && !Array.isArray(progress)) {
+        progressRef.current = progress as GameProgress
+      }
+    },
+  })
+
   // Keep ref in sync
   useEffect(() => { stateRef.current = state }, [state])
 
@@ -117,11 +133,11 @@ export default function PitchDefender() {
 
   // ─── Persist FSRS memory ─────────────────────────────────────────────────
   const saveFsrs = useCallback(() => {
-    try { localStorage.setItem(FSRS_KEY, JSON.stringify(fsrsRef.current)) } catch { /* */ }
+    savePitchScore(FSRS_KEY, fsrsRef.current)
   }, [])
 
   const saveProgress = useCallback(() => {
-    try { localStorage.setItem(PROGRESS_KEY, JSON.stringify(progressRef.current)) } catch { /* */ }
+    savePitchScore(PROGRESS_KEY, progressRef.current)
   }, [])
 
   // ─── Game Tick (check escapes, wave completion) ──────────────────────────
@@ -433,7 +449,7 @@ export default function PitchDefender() {
     const grade = autoGrade(correct, latency)
     if (!fsrsRef.current[alienNote]) fsrsRef.current[alienNote] = createNote(alienNote)
     fsrsRef.current[alienNote] = reviewNote(fsrsRef.current[alienNote], grade)
-    try { localStorage.setItem(FSRS_KEY, JSON.stringify(fsrsRef.current)) } catch {}
+    savePitchScore(FSRS_KEY, fsrsRef.current)
 
     if (correct) {
       // ─── CORRECT — side effects first ───

--- a/src/components/PitchDefender/RetroBlaster.tsx
+++ b/src/components/PitchDefender/RetroBlaster.tsx
@@ -25,6 +25,7 @@ import { INTRO_ORDER, UNLOCK_THRESHOLDS } from './types'
 import { usePitchDetection } from './usePitchDetection'
 import { initAudio, loadPianoSamples, playPianoNote } from './audioEngine'
 import { noteToFreq, octaveFoldedCents } from './pitchMath'
+import { savePitchScore, usePitchScoreSync } from './scoreSync'
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -436,6 +437,17 @@ export default function RetroBlaster() {
   // Mic detection
   const { isListening, startListening, stopListening, pitchRef: livePitchRef } = usePitchDetection({ noiseGateDb: -45 })
   const hitProcessingRef = useRef(false)
+
+  usePitchScoreSync({
+    keys: [FSRS_KEY],
+    onHydrate: (scores) => {
+      const fsrs = scores[FSRS_KEY]?.payload
+      if (fsrs && typeof fsrs === 'object' && !Array.isArray(fsrs)) {
+        fsrsRef.current = fsrs as Record<string, NoteMemory>
+      }
+    },
+  })
+
   // Pitchforks v1 lock pattern: matchStartRef holds the time the current
   // in-tolerance hold began (ms timestamp from performance.now()), or 0 when
   // not locking, or -1 during the post-fire cooldown. matchTargetIdxRef tracks
@@ -599,7 +611,7 @@ export default function RetroBlaster() {
       // FSRS update against the alien actually shot
       if (!fsrsRef.current[target.note]) fsrsRef.current[target.note] = createNote(target.note)
       fsrsRef.current[target.note] = reviewNote(fsrsRef.current[target.note], grade)
-      try { localStorage.setItem(FSRS_KEY, JSON.stringify(fsrsRef.current)) } catch {}
+      savePitchScore(FSRS_KEY, fsrsRef.current)
 
       sfxShoot()
       // Auto-aim: slide ship under the chosen alien, fire from there

--- a/src/components/PitchDefender/SimplySing.tsx
+++ b/src/components/PitchDefender/SimplySing.tsx
@@ -31,6 +31,7 @@ import { PitchFusion, type FusedPitch } from './pitchFusion'
 import { initAudio, loadPianoSamples, playPianoNote, markToneEmitted, setPianoVolume } from './audioEngine'
 import { extractMelodyFromComposition, type ExtractedNote, compositionHasNotes } from './composerExtract'
 import { noteToFreq, octaveFoldedCents, PITCH_ON_TOLERANCE_CENTS } from './pitchMath'
+import { usePitchScoreSync } from './scoreSync'
 
 // ─── Layout constants (logical pixels) ─────────────────────────────────────
 
@@ -214,12 +215,21 @@ export default function SimplySing() {
   const ribbonStatsRef = useRef<Map<number, RibbonStats>>(new Map())  // key = note index in song.notes
   const rafRef = useRef(0)
   const lastTickRef = useRef(0)
+  const refreshSongs = useCallback(() => {
+    setSongs(loadAllSongs())
+  }, [])
+
+  usePitchScoreSync({
+    keys: [],
+    includeCompositions: true,
+    onHydrate: refreshSongs,
+  })
 
   // Load composer songs on mount
   useEffect(() => {
     loadPianoSamples()
-    setSongs(loadAllSongs())
-  }, [])
+    refreshSongs()
+  }, [refreshSongs])
 
   // Push the piano ("plunk") volume to the shared audio engine whenever it changes.
   useEffect(() => {
@@ -228,8 +238,8 @@ export default function SimplySing() {
 
   // Refresh song list when returning to menu
   useEffect(() => {
-    if (phase === 'menu') setSongs(loadAllSongs())
-  }, [phase])
+    if (phase === 'menu') refreshSongs()
+  }, [phase, refreshSongs])
 
   // ─── Mic startup / teardown ───────────────────────────────────────────────
   const startMic = useCallback(async () => {

--- a/src/components/PitchDefender/SynthesiaRunner.tsx
+++ b/src/components/PitchDefender/SynthesiaRunner.tsx
@@ -24,6 +24,7 @@ import { NOTE_COLORS } from '@/lib/fsrs'
 import { initAudio, playPianoNote, loadPianoSamples, setPianoVolume } from './audioEngine'
 import { extractNotesFromXML, notesToSemitoneArray, type ExtractionResult } from './extractNotes'
 import { extractMelodyFromComposition } from './composerExtract'
+import { usePitchScoreSync } from './scoreSync'
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -164,7 +165,7 @@ export default function SynthesiaRunner() {
   // Uses the shared composerExtract module so every consumer reads the same
   // way (handles both new measures format AND legacy flat-notes fallback).
   const [composedSongs, setComposedSongs] = useState<{ name: string; notes: SongNote[]; description: string }[]>([])
-  useEffect(() => {
+  const refreshComposedSongs = useCallback(() => {
     const clampToKeyboard = (semi: number): number => {
       let v = semi
       while (v < KEYBOARD_LOW) v += 12
@@ -192,6 +193,12 @@ export default function SynthesiaRunner() {
       setComposedSongs(out)
     } catch {}
   }, [])
+  usePitchScoreSync({
+    keys: [],
+    includeCompositions: true,
+    onHydrate: refreshComposedSongs,
+  })
+  useEffect(() => { refreshComposedSongs() }, [refreshComposedSongs])
 
   const allSongs = [...SONGS, ...composedSongs, ...customSongs]
 

--- a/src/components/PitchDefender/VocalTrainerII.tsx
+++ b/src/components/PitchDefender/VocalTrainerII.tsx
@@ -28,6 +28,7 @@ import { recordResult, pickDepth, reinsert, createItem } from './engine/masteryQ
 import { usePitchDetection, type PitchInfo } from './usePitchDetection'
 import { PITCH_ON_TOLERANCE_CENTS } from './pitchMath'
 import type { RawNote } from './extractNotesFromAudio'
+import { savePitchScore, usePitchScoreSync } from './scoreSync'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -253,6 +254,16 @@ export default function VocalTrainerII() {
   // Sync live pitch state from hook
   useEffect(() => { setLivePitch(pitch) }, [pitch])
 
+  usePitchScoreSync({
+    keys: [STORAGE_KEY],
+    onHydrate: (scores) => {
+      const payload = scores[STORAGE_KEY]?.payload
+      if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+        setPersisted(payload as Persisted)
+      }
+    },
+  })
+
   // ─── Persistence ──────────────────────────────────────────────────────────
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -265,7 +276,7 @@ export default function VocalTrainerII() {
   const persist = useCallback((next: Persisted) => {
     setPersisted(next)
     if (typeof window === 'undefined') return
-    try { window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next)) } catch { /* quota */ }
+    try { savePitchScore(STORAGE_KEY, next) } catch { /* quota */ }
   }, [])
 
   // ─── Library fetch ────────────────────────────────────────────────────────

--- a/src/components/PitchDefender/VocalTrainerIII.tsx
+++ b/src/components/PitchDefender/VocalTrainerIII.tsx
@@ -41,6 +41,7 @@ import ScoreViewer from './ScoreViewer';
 import ScoreEngraving from './ScoreEngraving';
 import { getOmrTarget } from './omrTargets';
 import { SoundTouch, SimpleFilter, WebAudioBufferSource } from 'soundtouchjs';
+import { removePitchScore, savePitchScore, usePitchScoreSync } from './scoreSync';
 
 // V3.7 — Pitch-preserving time-stretch (the Tempo Trainer).
 // Render `buffer` to a NEW AudioBuffer whose duration is scaled by 1/speed
@@ -940,6 +941,16 @@ export default function VocalTrainerIII() {
   useEffect(() => { currentTemplateRef.current = currentTemplate; }, [currentTemplate]);
   useEffect(() => { playbackLabelRef.current = playbackLabel; }, [playbackLabel]);
   useEffect(() => { practiceTimeRef.current = practiceTime; }, [practiceTime]);
+  usePitchScoreSync({
+    keys: [TAKE_HISTORY_KEY, ENGRAVING_REPORTS_KEY],
+    onHydrate: (scores) => {
+      const takes = scores[TAKE_HISTORY_KEY]?.payload;
+      if (Array.isArray(takes)) setTakeHistory(takes as TakeSummary[]);
+
+      const reports = scores[ENGRAVING_REPORTS_KEY]?.payload;
+      if (Array.isArray(reports)) setEngravingReports(reports as EngravingReport[]);
+    },
+  });
   useEffect(() => {
     if (typeof window === 'undefined') return;
     try {
@@ -972,13 +983,13 @@ export default function VocalTrainerIII() {
     };
     setTakeHistory((prev) => {
       const next = [summary, ...prev].slice(0, 10);
-      try { localStorage.setItem(TAKE_HISTORY_KEY, JSON.stringify(next)); } catch {}
+      savePitchScore(TAKE_HISTORY_KEY, next);
       return next;
     });
   }, []);
   const clearTakeHistory = useCallback(() => {
     setTakeHistory([]);
-    try { localStorage.removeItem(TAKE_HISTORY_KEY); } catch {}
+    removePitchScore(TAKE_HISTORY_KEY);
   }, []);
 
   // Editor scroll container for auto-scrolling the piano-roll with the playhead.
@@ -2530,7 +2541,7 @@ export default function VocalTrainerIII() {
     };
     setEngravingReports((prev) => {
       const next = [report, ...prev].slice(0, 12);
-      try { localStorage.setItem(ENGRAVING_REPORTS_KEY, JSON.stringify(next)); } catch {}
+      savePitchScore(ENGRAVING_REPORTS_KEY, next);
       return next;
     });
     try {

--- a/src/components/PitchDefender/extractNotesFromAudio.ts
+++ b/src/components/PitchDefender/extractNotesFromAudio.ts
@@ -10,6 +10,8 @@
 // Used by VocalTrainer.tsx. The model (~13MB) is fetched from CDN and cached.
 // ═══════════════════════════════════════════════════════════════════════════════
 
+import { savePitchScore } from './scoreSync';
+
 const MODEL_URL = 'https://cdn.jsdelivr.net/npm/@spotify/basic-pitch@1.0.1/model/model.json';
 const TARGET_SR = 22050;
 
@@ -237,7 +239,7 @@ export function publishToSynthesia(template: { id: string; title: string; songNo
     publishedAt: new Date().toISOString(),
   };
   try {
-    localStorage.setItem(key, JSON.stringify(payload));
+    savePitchScore(key, payload, { updatedAt: payload.publishedAt });
   } catch (e) {
     console.warn('[vocal-trainer] failed to publish to Synthesia:', e);
   }

--- a/src/components/PitchDefender/scoreSync.ts
+++ b/src/components/PitchDefender/scoreSync.ts
@@ -1,0 +1,323 @@
+'use client'
+
+import { useEffect, useMemo, useRef } from 'react'
+import { useUser } from '@auth0/nextjs-auth0'
+
+export const PITCH_SCORE_SYNC_META_KEY = 'pitch_score_sync_meta_v1'
+
+export const PITCH_SCORE_STATIC_KEYS = [
+  'pitch_fsrs_memory',
+  'pitch_defender_progress',
+  'pitch_drill_progress',
+  'nt_v2_state',
+  'lt_v1_state',
+  'vt2_v1_state',
+  'vt3_take_summaries_v1',
+  'vt3_engraving_reports_v1',
+  'pitch_custom_songs',
+] as const
+
+export const PITCH_SCORE_DYNAMIC_PREFIXES = ['pd_composed_'] as const
+
+export interface PitchScoreEnvelope<T = unknown> {
+  payload: T
+  updatedAt: string
+  serverUpdatedAt?: string
+}
+
+type PitchScoreMap = Record<string, PitchScoreEnvelope>
+type MetaMap = Record<string, string>
+
+let signedInSyncEnabled = false
+const pendingPushes = new Map<string, ReturnType<typeof setTimeout>>()
+
+function nowIso() {
+  return new Date().toISOString()
+}
+
+function isValidDate(value: string | undefined): value is string {
+  return Boolean(value && !Number.isNaN(new Date(value).getTime()))
+}
+
+function parseJson(raw: string | null): unknown | undefined {
+  if (!raw) return undefined
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+}
+
+function readMeta(): MetaMap {
+  if (typeof window === 'undefined') return {}
+  const parsed = parseJson(window.localStorage.getItem(PITCH_SCORE_SYNC_META_KEY))
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? parsed as MetaMap
+    : {}
+}
+
+function writeMeta(meta: MetaMap) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(PITCH_SCORE_SYNC_META_KEY, JSON.stringify(meta))
+  } catch {
+    // localStorage is best-effort; gameplay must never block on sync metadata.
+  }
+}
+
+function payloadTimestamp(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null
+  const record = payload as Record<string, unknown>
+  for (const key of ['updatedAt', 'savedAt', 'publishedAt', 'createdAt']) {
+    const candidate = record[key]
+    if (typeof candidate === 'string' && isValidDate(candidate)) return candidate
+  }
+  return null
+}
+
+function shouldSyncKey(key: string, keys: Set<string>, includeCompositions: boolean): boolean {
+  if (keys.has(key)) return true
+  return includeCompositions && PITCH_SCORE_DYNAMIC_PREFIXES.some(prefix => key.startsWith(prefix))
+}
+
+function readLocalEnvelope(key: string, meta: MetaMap): PitchScoreEnvelope | null {
+  if (typeof window === 'undefined') return null
+  const payload = parseJson(window.localStorage.getItem(key))
+  if (payload === undefined) return null
+
+  const updatedAt = isValidDate(meta[key])
+    ? meta[key]
+    : payloadTimestamp(payload) ?? nowIso()
+
+  if (meta[key] !== updatedAt) {
+    meta[key] = updatedAt
+    writeMeta(meta)
+  }
+
+  return { payload, updatedAt }
+}
+
+function writeLocalEnvelope(key: string, envelope: PitchScoreEnvelope) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(key, JSON.stringify(envelope.payload))
+    const meta = readMeta()
+    meta[key] = envelope.updatedAt
+    writeMeta(meta)
+  } catch {
+    // Offline/local play continues even if persistence is unavailable.
+  }
+}
+
+function collectLocalScores(keys: Set<string>, includeCompositions: boolean): PitchScoreMap {
+  if (typeof window === 'undefined') return {}
+
+  const meta = readMeta()
+  const out: PitchScoreMap = {}
+  for (const key of keys) {
+    const envelope = readLocalEnvelope(key, meta)
+    if (envelope) out[key] = envelope
+  }
+
+  if (includeCompositions) {
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i)
+      if (!key || !shouldSyncKey(key, keys, true)) continue
+      const envelope = readLocalEnvelope(key, meta)
+      if (envelope) out[key] = envelope
+    }
+  }
+
+  return out
+}
+
+async function pushScore(key: string, envelope: PitchScoreEnvelope) {
+  if (!signedInSyncEnabled) return
+
+  try {
+    const response = await fetch('/api/pitch-scores', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        scores: [{
+          gameKey: key,
+          payload: envelope.payload,
+          updatedAt: envelope.updatedAt,
+        }],
+      }),
+    })
+
+    if (response.status === 401) {
+      signedInSyncEnabled = false
+      return
+    }
+
+    if (!response.ok) {
+      console.warn('[pitch-score-sync] push failed', response.status)
+    }
+  } catch (error) {
+    console.warn('[pitch-score-sync] push failed', error)
+  }
+}
+
+async function deleteScore(key: string) {
+  if (!signedInSyncEnabled) return
+
+  try {
+    const response = await fetch('/api/pitch-scores', {
+      method: 'DELETE',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ gameKey: key }),
+    })
+
+    if (response.status === 401) {
+      signedInSyncEnabled = false
+      return
+    }
+
+    if (!response.ok) {
+      console.warn('[pitch-score-sync] delete failed', response.status)
+    }
+  } catch (error) {
+    console.warn('[pitch-score-sync] delete failed', error)
+  }
+}
+
+function queuePush(key: string, envelope: PitchScoreEnvelope, debounceMs = 800) {
+  if (!signedInSyncEnabled) return
+
+  const existing = pendingPushes.get(key)
+  if (existing) clearTimeout(existing)
+  pendingPushes.set(key, setTimeout(() => {
+    pendingPushes.delete(key)
+    void pushScore(key, envelope)
+  }, debounceMs))
+}
+
+export function savePitchScore<T>(key: string, payload: T, options: { updatedAt?: string; debounceMs?: number } = {}) {
+  const updatedAt = isValidDate(options.updatedAt) ? options.updatedAt : nowIso()
+  const envelope: PitchScoreEnvelope<T> = { payload, updatedAt }
+  writeLocalEnvelope(key, envelope)
+  queuePush(key, envelope, options.debounceMs)
+  return updatedAt
+}
+
+export function loadPitchScore<T>(key: string, fallback: T): T {
+  if (typeof window === 'undefined') return fallback
+  const payload = parseJson(window.localStorage.getItem(key))
+  return payload === undefined ? fallback : payload as T
+}
+
+export function removePitchScore(key: string) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.removeItem(key)
+    const meta = readMeta()
+    delete meta[key]
+    writeMeta(meta)
+    const pending = pendingPushes.get(key)
+    if (pending) clearTimeout(pending)
+    pendingPushes.delete(key)
+    void deleteScore(key)
+  } catch {
+    // no-op
+  }
+}
+
+export function usePitchScoreSync(options: {
+  keys?: readonly string[]
+  includeCompositions?: boolean
+  onHydrate?: (scores: PitchScoreMap) => void
+} = {}) {
+  const { user, isLoading } = useUser()
+  const onHydrateRef = useRef(options.onHydrate)
+  onHydrateRef.current = options.onHydrate
+
+  const keys = useMemo(
+    () => new Set(options.keys ?? PITCH_SCORE_STATIC_KEYS),
+    [options.keys],
+  )
+  const keySignature = useMemo(
+    () => Array.from(keys).sort().join('|'),
+    [keys],
+  )
+  const includeCompositions = options.includeCompositions ?? false
+  const hydrationRunRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || isLoading) return
+
+    if (!user) {
+      signedInSyncEnabled = false
+      return
+    }
+
+    signedInSyncEnabled = true
+    const userKey = `${user.sub ?? user.email ?? 'auth0-user'}:${keySignature}:${includeCompositions}`
+    if (hydrationRunRef.current === userKey) return
+    hydrationRunRef.current = userKey
+
+    let cancelled = false
+
+    async function hydrate() {
+      const localScores = collectLocalScores(keys, includeCompositions)
+
+      try {
+        const response = await fetch('/api/pitch-scores', {
+          method: 'GET',
+          credentials: 'same-origin',
+          cache: 'no-store',
+        })
+
+        if (response.status === 401) {
+          signedInSyncEnabled = false
+          return
+        }
+
+        if (!response.ok) {
+          console.warn('[pitch-score-sync] hydration failed', response.status)
+          return
+        }
+
+        const body = await response.json() as { scores?: PitchScoreMap }
+        const serverScores = body.scores ?? {}
+        const hydrated: PitchScoreMap = {}
+        const allKeys = new Set([
+          ...Object.keys(localScores),
+          ...Object.keys(serverScores).filter(key => shouldSyncKey(key, keys, includeCompositions)),
+        ])
+
+        for (const key of allKeys) {
+          const local = localScores[key]
+          const remote = serverScores[key]
+          if (!remote && local) {
+            queuePush(key, local, 0)
+            continue
+          }
+          if (!remote) continue
+
+          if (!local || new Date(remote.updatedAt).getTime() > new Date(local.updatedAt).getTime()) {
+            writeLocalEnvelope(key, remote)
+            hydrated[key] = remote
+          } else if (new Date(local.updatedAt).getTime() > new Date(remote.updatedAt).getTime()) {
+            queuePush(key, local, 0)
+          }
+        }
+
+        if (!cancelled && Object.keys(hydrated).length > 0) {
+          onHydrateRef.current?.(hydrated)
+        }
+      } catch (error) {
+        console.warn('[pitch-score-sync] hydration failed', error)
+      }
+    }
+
+    void hydrate()
+
+    return () => {
+      cancelled = true
+    }
+  }, [isLoading, user, keySignature, includeCompositions, keys])
+}


### PR DESCRIPTION
Linked worklist issue: https://github.com/jonchyatt/codex-worklist/issues/21

## Summary
- Added a Mongo-backed `GameScore` Prisma model keyed by `userId + gameKey` for Pitch Defender score/progress mirrors.
- Added authenticated `/api/pitch-scores` GET/POST/PUT/DELETE route using existing Auth0 + Prisma paths.
- Added a shared client sync helper that keeps localStorage as the immediate source of truth, hydrates newer server copies on signed-in load, and debounce-pushes local updates.
- Wired persistence-only sync into Pitch Defender progress/state owners: shared FSRS, main arcade progress, Drill, Note Tutor, Lyrics Trainer, VocalTrainerII, VocalTrainerIII take/report history, Composer `pd_composed_*`, quick-entry songs, and composition consumers.
- Left game UI, scoring math, and pitch-detection stack unchanged.

## Score key contract preserved
- `pitch_fsrs_memory`: `Record<string, NoteMemory>`.
- `pitch_defender_progress`: `{ highScore, bestWave, bestCombo, totalGamesPlayed, totalAliensDestroyed }`.
- `pitch_drill_progress`: `{ totalSessions, totalCards, bestStreak }`.
- `nt_v2_state`, `lt_v1_state`, `vt2_v1_state`, `vt3_take_summaries_v1`, `vt3_engraving_reports_v1`.
- `pitch_custom_songs`.
- Dynamic `pd_composed_*` composer/vocal-trainer payloads.
- UI-only local prefs remain local-only: `pitch_defender_settings`, `retro_tutorial_seen`, `retro_difficulty`, score-verify layout/verdicts, `vt3_favorites`, `vt3_orb_pos`.

## Verification
- `npx prisma generate` passed.
- `npx prisma validate` passed with dummy `DATABASE_URL=mongodb://localhost:27017/resetbiology`; existing schema warnings remain for `SuccessDeposit.userId` and `BreathSession.userId` native type mismatch.
- `npx tsc --noEmit` passed.
- `npm run build` passed; same pre-existing missing Auth0/env warnings and Next workspace-root/Auth0 Edge warnings.
- `git diff --check` passed; only repository line-ending warnings.
- Local unauthenticated API proof: GET/POST/PUT/DELETE `/api/pitch-scores` all returned `401`.
- Signed-out Chrome smoke across `/pitch-defender`, `/drill`, `/retro`, `/note-tutor`, `/lyrics-trainer`, `/vocal-trainer-2`, `/vocal-trainer-3`, `/composer`, `/note-entry`, `/note-runner`, `/synthesia`, `/choir-practice`, `/simply-sing`: all route responses were `200`, no runtime error text, no page exceptions, and zero `/api/pitch-scores` requests while signed out.
- Existing local 500s observed only on `/api/vocal-trainer/library` for VocalTrainerII/III because this machine has no local Auth0/DATABASE_URL configuration; unrelated to the new score route.

## Manual signed-in A/B test to run in configured env
Local machine lacks `.env.local`, so the true signed-in DB mirror test could not be executed here. In staging/production with Auth0 + DATABASE_URL configured:
1. Sign in on device A, open `/pitch-defender/drill`, complete a card so `pitch_fsrs_memory` and `pitch_drill_progress` update.
2. Confirm `GET /api/pitch-scores` returns those keys with the new `updatedAt` values.
3. Sign in as the same user on device B, open `/pitch-defender/drill`, and confirm localStorage hydrates the newer server payload before continuing play.
4. Create a newer local score on device B, reload device A, and confirm newest `updatedAt` wins with no older payload overwrite.

## Deploy note
Prisma Mongo deploy step for this schema change:
```powershell
npx prisma db push
npx prisma generate
```