### PR TITLE
[worklist#15] Vision Training PRD defect sweep

### DIFF
--- a/src/components/Vision/Training/DistanceGuidance.tsx
+++ b/src/components/Vision/Training/DistanceGuidance.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Ruler, Monitor, Smartphone } from 'lucide-react'
+import { Monitor, Ruler, Smartphone } from 'lucide-react'
 
 interface DistanceGuidanceProps {
   targetDistanceCm: number
@@ -8,26 +8,26 @@ interface DistanceGuidanceProps {
   deviceMode?: 'phone' | 'desktop'
 }
 
-// Simple distance guidance (text-only) so users know how to position themselves.
 export default function DistanceGuidance({
   targetDistanceCm,
   visionType,
   deviceMode = 'phone'
 }: DistanceGuidanceProps) {
+  const recommendedRange = deviceMode === 'phone' ? '20-60 cm' : '60-100 cm'
+
   const getDistanceDescription = () => {
     if (deviceMode === 'phone') {
       if (targetDistanceCm <= 25) return "Close - about a hand's length away"
-      if (targetDistanceCm <= 40) return "Comfortable reading distance"
-      if (targetDistanceCm <= 60) return "Extended arm's length - push the blur"
-      return "Maximum arm's reach - challenge your edge of clarity"
+      if (targetDistanceCm <= 40) return 'Comfortable reading distance'
+      return "Extended arm's length - push the blur"
     }
-    // Desktop mode
-    if (targetDistanceCm <= 60) return "Close desktop viewing"
-    if (targetDistanceCm <= 80) return "Normal desk distance"
-    return "Extended desk distance - lean back slightly"
+
+    if (targetDistanceCm <= 60) return 'Close desktop viewing'
+    if (targetDistanceCm <= 80) return 'Normal desk distance'
+    return 'Extended desk distance - stay within reach'
   }
 
-  const isPhoneAppropriate = visionType === 'near' || targetDistanceCm <= 100
+  const isPhoneAppropriate = deviceMode !== 'phone' || targetDistanceCm <= 60
 
   return (
     <div className="bg-gray-900/40 border border-primary-400/30 rounded-lg p-4 shadow-inner">
@@ -37,7 +37,7 @@ export default function DistanceGuidance({
           <span className="text-white font-semibold">Distance Guide</span>
         </div>
         <div className="text-xl font-bold text-secondary-400">
-          {visionType === 'near' ? `${targetDistanceCm} cm` : `${(targetDistanceCm / 100).toFixed(1)} m`}
+          {targetDistanceCm} cm
         </div>
       </div>
 
@@ -73,16 +73,17 @@ export default function DistanceGuidance({
             <span>Consider switching to Desktop mode</span>
           </div>
           <p className="text-yellow-200/70 mt-1 text-xs">
-            Larger screens work better for advanced distance training.
+            Larger screens work better when training beyond arm's length.
           </p>
         </div>
       )}
 
       <div className="mt-3 text-xs text-gray-400 space-y-1">
-        <p>• Hold your {deviceMode === 'phone' ? 'phone' : 'screen'} at the distance shown above</p>
-        <p>• Keep your head still, move only your eyes</p>
-        <p>• Blink naturally between attempts</p>
-        <p>• Find your "edge of clarity" - where text is just barely readable</p>
+        <p>- Hold your {deviceMode === 'phone' ? 'phone' : 'screen'} at the distance shown above.</p>
+        <p>- Recommended {deviceMode === 'phone' ? 'phone' : 'desktop'} range: {recommendedRange}.</p>
+        <p>- Keep your head still, move only your eyes.</p>
+        <p>- Blink naturally between attempts.</p>
+        <p>- Find your edge of clarity, where text is just barely readable.</p>
       </div>
     </div>
   )

--- a/src/components/Vision/Training/DistanceTracker.tsx
+++ b/src/components/Vision/Training/DistanceTracker.tsx
@@ -14,17 +14,19 @@ export default function DistanceTracker({
   onDistanceChange,
   visionType
 }: DistanceTrackerProps) {
-  const [currentDistance, setCurrentDistance] = useState<number>(50)
+  const minDistanceCm = visionType === 'near' ? 20 : 60
+  const maxDistanceCm = visionType === 'near' ? 60 : 100
+  const clampDistance = (distanceCm: number) => {
+    return Math.min(maxDistanceCm, Math.max(minDistanceCm, Math.round(distanceCm)))
+  }
+
+  const [currentDistance, setCurrentDistance] = useState<number>(clampDistance(targetDistanceCm || 50))
   const [permissionGranted, setPermissionGranted] = useState(false)
   const [useManual, setUseManual] = useState(false)
 
   useEffect(() => {
-    // Check if device orientation API is available
     if (typeof window !== 'undefined' && 'DeviceOrientationEvent' in window) {
-      // Request permission on iOS 13+
-      if (
-        typeof (DeviceOrientationEvent as any).requestPermission === 'function'
-      ) {
+      if (typeof (DeviceOrientationEvent as any).requestPermission === 'function') {
         (DeviceOrientationEvent as any).requestPermission()
           .then((response: string) => {
             if (response === 'granted') {
@@ -36,7 +38,6 @@ export default function DistanceTracker({
           })
           .catch(() => setUseManual(true))
       } else {
-        // Permission not required (Android, desktop)
         setPermissionGranted(true)
         startTracking()
       }
@@ -45,31 +46,24 @@ export default function DistanceTracker({
     }
   }, [])
 
+  const updateDistance = (distanceCm: number) => {
+    const nextDistance = clampDistance(distanceCm)
+    setCurrentDistance(nextDistance)
+    onDistanceChange(nextDistance)
+  }
+
   const startTracking = () => {
-    // Simple distance estimation based on device tilt
-    // This is a rough approximation - real implementation would use camera API
     window.addEventListener('deviceorientation', handleOrientation)
   }
 
   const handleOrientation = (event: DeviceOrientationEvent) => {
-    const beta = event.beta || 0 // Forward/back tilt in degrees (-180 to 180)
+    const beta = event.beta || 0
+    const tiltOffset = Math.min(40, Math.abs(90 - Math.abs(beta)))
+    const estimatedDistance = visionType === 'near'
+      ? 20 + tiltOffset
+      : 60 + tiltOffset
 
-    // Map tilt angle to distance
-    // Assuming: 90° (vertical) = near distance, 45° = mid, 0° (flat) = far
-    let estimatedDistance = 40 // Default near vision distance in cm
-
-    if (visionType === 'near') {
-      // Near vision: 16-24 inches (40-60 cm)
-      estimatedDistance = 40 + Math.abs(90 - Math.abs(beta))
-    } else {
-      // Far vision: Convert to meters for far vision
-      // This is simplified - real app would need camera-based distance measurement
-      const meters = 3 + (Math.abs(beta) / 10)
-      estimatedDistance = meters * 100 // Convert to cm for consistency
-    }
-
-    setCurrentDistance(Math.round(estimatedDistance))
-    onDistanceChange(Math.round(estimatedDistance))
+    updateDistance(estimatedDistance)
   }
 
   useEffect(() => {
@@ -79,62 +73,41 @@ export default function DistanceTracker({
   }, [])
 
   const distanceDifference = currentDistance - targetDistanceCm
-  const isInRange = Math.abs(distanceDifference) < (visionType === 'near' ? 5 : 30)
+  const isInRange = Math.abs(distanceDifference) < (visionType === 'near' ? 5 : 10)
 
   return (
     <div className="bg-gray-900/40 border border-primary-400/30 rounded-lg p-4 shadow-inner">
-      {/* Distance display */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           <Ruler className="w-5 h-5 text-primary-400" />
           <span className="text-white font-semibold">Distance Tracking</span>
         </div>
         <div className={`text-2xl font-bold ${isInRange ? 'text-secondary-400' : 'text-yellow-400'}`}>
-          {visionType === 'near'
-            ? `${currentDistance} cm`
-            : `${(currentDistance / 100).toFixed(1)} m`
-          }
+          {currentDistance} cm
         </div>
       </div>
 
-      {/* Visual indicator */}
       <div className="mb-3">
         <div className="bg-gray-700 rounded-full h-3 overflow-hidden">
           <div
-            className={`h-full transition-all duration-300 ${
-              isInRange ? 'bg-secondary-400' : 'bg-yellow-400'
-            }`}
+            className={`h-full transition-all duration-300 ${isInRange ? 'bg-secondary-400' : 'bg-yellow-400'}`}
             style={{
-              width: `${Math.min(100, Math.max(0, (currentDistance / (targetDistanceCm * 2)) * 100))}%`
+              width: `${Math.min(100, Math.max(0, ((currentDistance - minDistanceCm) / (maxDistanceCm - minDistanceCm)) * 100))}%`
             }}
           />
         </div>
       </div>
 
-      {/* Guidance text */}
       <div className="text-sm">
         {isInRange ? (
-          <p className="text-secondary-400 font-semibold">✓ Perfect distance!</p>
+          <p className="text-secondary-400 font-semibold">Perfect distance.</p>
         ) : distanceDifference > 0 ? (
-          <p className="text-yellow-400">
-            Move closer (
-            {visionType === 'near'
-              ? `${Math.abs(distanceDifference)} cm too far`
-              : `${(Math.abs(distanceDifference) / 100).toFixed(1)} m too far`
-            })
-          </p>
+          <p className="text-yellow-400">Move closer ({Math.abs(distanceDifference)} cm too far).</p>
         ) : (
-          <p className="text-yellow-400">
-            Move back (
-            {visionType === 'near'
-              ? `${Math.abs(distanceDifference)} cm too close`
-              : `${(Math.abs(distanceDifference) / 100).toFixed(1)} m too close`
-            })
-          </p>
+          <p className="text-yellow-400">Move back ({Math.abs(distanceDifference)} cm too close).</p>
         )}
       </div>
 
-      {/* Manual override for devices without sensors */}
       {useManual && (
         <div className="mt-4 pt-4 border-t border-gray-600">
           <label className="text-white text-sm block mb-2">
@@ -142,25 +115,20 @@ export default function DistanceTracker({
           </label>
           <input
             type="range"
-            min={visionType === 'near' ? 30 : 100}
-            max={visionType === 'near' ? 80 : 800}
+            min={minDistanceCm}
+            max={maxDistanceCm}
             value={currentDistance}
-            onChange={(e) => {
-              const val = parseInt(e.target.value)
-              setCurrentDistance(val)
-              onDistanceChange(val)
-            }}
+            onChange={(event) => updateDistance(parseInt(event.target.value))}
             className="w-full"
           />
           <p className="text-xs text-gray-400 mt-1">
-            Use slider if device sensors aren't available
+            Use slider if device sensors are not available.
           </p>
         </div>
       )}
 
-      {/* Target distance info */}
       <div className="mt-3 text-xs text-gray-400 text-center">
-        Target: {visionType === 'near' ? `${targetDistanceCm} cm` : `${(targetDistanceCm / 100).toFixed(1)} m`}
+        Target: {clampDistance(targetDistanceCm)} cm
       </div>
     </div>
   )

--- a/src/components/Vision/Training/LessonHistory.tsx
+++ b/src/components/Vision/Training/LessonHistory.tsx
@@ -1,0 +1,263 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import {
+  CalendarDays,
+  CheckCircle,
+  Circle,
+  Clock,
+  Lock,
+  Play,
+  RotateCcw
+} from 'lucide-react'
+import { visionMasterProgram } from '@/data/visionProtocols'
+
+interface CompletedSession {
+  week: number
+  day: number
+  sessionTitle: string
+  completedAt: string
+  localDate: string
+}
+
+interface LessonHistoryProps {
+  enrollment: {
+    startDate?: string
+    currentWeek: number
+    currentDay: number
+  }
+  completedSessions: CompletedSession[]
+  onMakeUpLesson: (week: number, day: number, localDate?: string) => Promise<void>
+  onStartSession: (week: number, day: number) => void
+}
+
+type LessonStatus = 'completed' | 'today' | 'missed' | 'upcoming'
+
+interface LessonDay {
+  week: number
+  day: number
+  title: string
+  focus: string
+  minutes: number
+  exerciseCount: number
+  localDate?: string
+  status: LessonStatus
+}
+
+function keyFor(week: number, day: number) {
+  return `${week}-${day}`
+}
+
+function formatLocalDate(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function scheduledDate(startDate: string | undefined, week: number, day: number) {
+  if (!startDate) return undefined
+  const date = new Date(startDate)
+  date.setDate(date.getDate() + (week - 1) * 7 + day - 1)
+  return formatLocalDate(date)
+}
+
+function statusClasses(status: LessonStatus, selected: boolean) {
+  const base = selected ? 'ring-2 ring-white/70 ' : ''
+  if (status === 'completed') return `${base}bg-green-600/25 border-green-400/50 text-green-100`
+  if (status === 'today') return `${base}bg-primary-600/30 border-primary-400/60 text-white`
+  if (status === 'missed') return `${base}bg-yellow-600/20 border-yellow-400/40 text-yellow-100`
+  return `${base}bg-gray-800/35 border-gray-600/30 text-gray-400`
+}
+
+function StatusIcon({ status }: { status: LessonStatus }) {
+  if (status === 'completed') return <CheckCircle className="w-4 h-4 text-green-300" />
+  if (status === 'today') return <Play className="w-4 h-4 text-primary-300" />
+  if (status === 'missed') return <Clock className="w-4 h-4 text-yellow-300" />
+  return <Lock className="w-4 h-4 text-gray-500" />
+}
+
+export default function LessonHistory({
+  enrollment,
+  completedSessions,
+  onMakeUpLesson,
+  onStartSession
+}: LessonHistoryProps) {
+  const [markingKey, setMarkingKey] = useState<string | null>(null)
+
+  const completedMap = useMemo(() => {
+    return new Map(completedSessions.map((session) => [keyFor(session.week, session.day), session]))
+  }, [completedSessions])
+
+  const currentOrdinal = (enrollment.currentWeek - 1) * 5 + Math.min(enrollment.currentDay, 5)
+
+  const lessons = useMemo<LessonDay[]>(() => {
+    return visionMasterProgram.weeklyPlans.flatMap((weekPlan) =>
+      weekPlan.sessions.map((session) => {
+        const key = keyFor(weekPlan.week, session.day)
+        const ordinal = (weekPlan.week - 1) * 5 + session.day
+        const completed = completedMap.has(key)
+        const status: LessonStatus = completed
+          ? 'completed'
+          : ordinal === currentOrdinal
+            ? 'today'
+            : ordinal < currentOrdinal
+              ? 'missed'
+              : 'upcoming'
+
+        return {
+          week: weekPlan.week,
+          day: session.day,
+          title: session.title,
+          focus: session.focus,
+          minutes: session.baselineMinutes + session.exerciseMinutes,
+          exerciseCount: session.exerciseIds.length,
+          localDate: scheduledDate(enrollment.startDate, weekPlan.week, session.day),
+          status
+        }
+      })
+    )
+  }, [completedMap, currentOrdinal, enrollment.startDate])
+
+  const initialLesson = lessons.find((lesson) => lesson.status === 'missed')
+    || lessons.find((lesson) => lesson.status === 'today')
+    || lessons[0]
+  const [selectedKey, setSelectedKey] = useState(() => initialLesson ? keyFor(initialLesson.week, initialLesson.day) : '')
+
+  const selectedLesson = lessons.find((lesson) => keyFor(lesson.week, lesson.day) === selectedKey) || initialLesson
+  const completedCount = lessons.filter((lesson) => lesson.status === 'completed').length
+  const missedCount = lessons.filter((lesson) => lesson.status === 'missed').length
+  const upcomingCount = lessons.filter((lesson) => lesson.status === 'upcoming').length
+
+  const handleMakeUp = async (lesson: LessonDay) => {
+    const key = keyFor(lesson.week, lesson.day)
+    setMarkingKey(key)
+    try {
+      await onMakeUpLesson(lesson.week, lesson.day, lesson.localDate)
+    } finally {
+      setMarkingKey(null)
+    }
+  }
+
+  return (
+    <div className="bg-gradient-to-br from-gray-800/80 to-gray-900/80 backdrop-blur-sm rounded-xl p-6 border border-primary-400/20 shadow-lg">
+      <div className="flex items-start justify-between gap-4 mb-5">
+        <div>
+          <h2 className="text-xl font-bold text-white flex items-center gap-2">
+            <CalendarDays className="w-5 h-5 text-primary-400" />
+            Lesson History
+          </h2>
+          <p className="text-sm text-gray-400 mt-1">
+            Review completed, missed, and upcoming lessons across the 12-week plan.
+          </p>
+        </div>
+        <div className="hidden sm:flex items-center gap-3 text-xs">
+          <span className="flex items-center gap-1 text-green-300"><CheckCircle className="w-3 h-3" />{completedCount}</span>
+          <span className="flex items-center gap-1 text-yellow-300"><Clock className="w-3 h-3" />{missedCount}</span>
+          <span className="flex items-center gap-1 text-gray-400"><Circle className="w-3 h-3" />{upcomingCount}</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_320px] gap-5">
+        <div className="space-y-3">
+          {visionMasterProgram.weeklyPlans.map((weekPlan) => (
+            <div key={weekPlan.week} className="bg-gray-900/35 rounded-lg p-3 border border-gray-700/35">
+              <div className="flex items-center justify-between mb-2">
+                <div>
+                  <p className="text-white font-semibold text-sm">Week {weekPlan.week}</p>
+                  <p className="text-xs text-gray-500">{weekPlan.title}</p>
+                </div>
+                <p className="text-xs text-primary-300">{weekPlan.phase}</p>
+              </div>
+              <div className="grid grid-cols-5 gap-2">
+                {lessons
+                  .filter((lesson) => lesson.week === weekPlan.week)
+                  .map((lesson) => {
+                    const key = keyFor(lesson.week, lesson.day)
+                    return (
+                      <button
+                        key={key}
+                        onClick={() => setSelectedKey(key)}
+                        className={`min-h-[52px] rounded-lg border p-2 text-left transition-all hover:border-white/40 ${statusClasses(lesson.status, selectedKey === key)}`}
+                      >
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs font-bold">D{lesson.day}</span>
+                          <StatusIcon status={lesson.status} />
+                        </div>
+                        <p className="text-[10px] mt-1 truncate" title={lesson.title}>{lesson.title}</p>
+                      </button>
+                    )
+                  })}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {selectedLesson && (
+          <div className="bg-gray-900/45 rounded-xl p-4 border border-primary-400/20 h-fit sticky top-32">
+            <div className="flex items-center gap-2 mb-3">
+              <StatusIcon status={selectedLesson.status} />
+              <span className="text-xs uppercase tracking-wide text-gray-400">
+                Week {selectedLesson.week}, Day {selectedLesson.day}
+              </span>
+            </div>
+            <h3 className="text-lg font-bold text-white mb-1">{selectedLesson.title}</h3>
+            <p className="text-sm text-gray-300 mb-3">{selectedLesson.focus}</p>
+
+            <div className="grid grid-cols-2 gap-2 mb-4">
+              <div className="bg-gray-800/60 rounded-lg p-3">
+                <p className="text-xs text-gray-500">Duration</p>
+                <p className="text-white font-semibold">{selectedLesson.minutes} min</p>
+              </div>
+              <div className="bg-gray-800/60 rounded-lg p-3">
+                <p className="text-xs text-gray-500">Exercises</p>
+                <p className="text-white font-semibold">{selectedLesson.exerciseCount}</p>
+              </div>
+            </div>
+
+            {selectedLesson.localDate && (
+              <p className="text-xs text-gray-500 mb-4">Scheduled: {selectedLesson.localDate}</p>
+            )}
+
+            {selectedLesson.status === 'completed' && (
+              <div className="rounded-lg bg-green-600/15 border border-green-400/30 p-3 text-sm text-green-200">
+                Completed{completedMap.get(keyFor(selectedLesson.week, selectedLesson.day))?.localDate
+                  ? ` on ${completedMap.get(keyFor(selectedLesson.week, selectedLesson.day))?.localDate}`
+                  : ''}
+              </div>
+            )}
+
+            {selectedLesson.status === 'today' && (
+              <button
+                onClick={() => onStartSession(selectedLesson.week, selectedLesson.day)}
+                className="w-full flex items-center justify-center gap-2 rounded-lg bg-primary-600 hover:bg-primary-500 text-white font-semibold py-3 transition-colors"
+              >
+                <Play className="w-4 h-4" />
+                Start today's lesson
+              </button>
+            )}
+
+            {selectedLesson.status === 'missed' && (
+              <button
+                onClick={() => handleMakeUp(selectedLesson)}
+                disabled={markingKey === keyFor(selectedLesson.week, selectedLesson.day)}
+                className="w-full flex items-center justify-center gap-2 rounded-lg bg-yellow-600 hover:bg-yellow-500 disabled:opacity-60 text-white font-semibold py-3 transition-colors"
+              >
+                {markingKey === keyFor(selectedLesson.week, selectedLesson.day)
+                  ? <div className="w-4 h-4 border border-white/40 border-t-white rounded-full animate-spin" />
+                  : <RotateCcw className="w-4 h-4" />}
+                Make up this lesson
+              </button>
+            )}
+
+            {selectedLesson.status === 'upcoming' && (
+              <div className="rounded-lg bg-gray-800/50 border border-gray-700/40 p-3 text-sm text-gray-400">
+                This lesson unlocks as the program calendar advances.
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Vision/Training/ProgramProgress.tsx
+++ b/src/components/Vision/Training/ProgramProgress.tsx
@@ -20,6 +20,7 @@ import {
   Lock
 } from 'lucide-react'
 import { visionMasterProgram } from '@/data/visionProtocols'
+import LessonHistory from './LessonHistory'
 
 interface CompletedSession {
   week: number
@@ -31,6 +32,7 @@ interface CompletedSession {
 
 interface ProgramProgressProps {
   enrollment: {
+    startDate?: string
     currentWeek: number
     currentDay: number
     sessionsCompleted: number
@@ -46,7 +48,7 @@ interface ProgramProgressProps {
     }
   }
   completedSessions: CompletedSession[]
-  onMarkComplete: (week: number, day: number) => Promise<void>
+  onMarkComplete: (week: number, day: number, localDate?: string) => Promise<void>
   onStartSession: (week: number, day: number) => void
 }
 
@@ -171,6 +173,13 @@ export default function ProgramProgress({
           </div>
         </div>
       </div>
+
+      <LessonHistory
+        enrollment={enrollment}
+        completedSessions={completedSessions}
+        onMakeUpLesson={onMarkComplete}
+        onStartSession={onStartSession}
+      />
 
       {/* 12-Week Plan with Completion Status */}
       <div className="bg-gradient-to-br from-gray-800/80 to-gray-900/80 backdrop-blur-sm rounded-xl p-6 border border-primary-400/20 shadow-lg">
@@ -345,7 +354,7 @@ export default function ProgramProgress({
                                             ) : (
                                               <CheckCircle className="w-3 h-3" />
                                             )}
-                                            Mark Done
+                                            Make Up
                                           </button>
                                         ) : (
                                           <span className="text-xs text-gray-500">Upcoming</span>

--- a/src/components/Vision/Training/ProgressDashboard.tsx
+++ b/src/components/Vision/Training/ProgressDashboard.tsx
@@ -24,6 +24,12 @@ interface VisionSession {
   createdAt: string
 }
 
+function formatTrainingDistance(distanceCm: number) {
+  const rounded = Math.round(distanceCm)
+  if (rounded > 100) return '100 cm cap'
+  return `${rounded} cm`
+}
+
 export default function ProgressDashboard() {
   const [progress, setProgress] = useState<VisionProgress[]>([])
   const [recentSessions, setRecentSessions] = useState<VisionSession[]>([])
@@ -117,7 +123,7 @@ export default function ProgressDashboard() {
               <div className="flex justify-between items-center">
                 <span className="text-gray-400">Best Distance:</span>
                 <span className="text-secondary-400 font-semibold">
-                  {nearProgress.maxDistanceCm} cm
+                  {formatTrainingDistance(nearProgress.maxDistanceCm)}
                 </span>
               </div>
               <div className="flex justify-between items-center">
@@ -155,7 +161,7 @@ export default function ProgressDashboard() {
               <div className="flex justify-between items-center">
                 <span className="text-gray-400">Best Distance:</span>
                 <span className="text-secondary-400 font-semibold">
-                  {(farProgress.maxDistanceCm / 100).toFixed(1)} m
+                  {formatTrainingDistance(farProgress.maxDistanceCm)}
                 </span>
               </div>
               <div className="flex justify-between items-center">
@@ -208,9 +214,7 @@ export default function ProgressDashboard() {
                   </div>
                   <p className="text-xs text-gray-400">
                     {new Date(session.createdAt).toLocaleString()} • {
-                      session.visionType === 'near'
-                        ? `${session.distanceCm} cm`
-                        : `${(session.distanceCm / 100).toFixed(1)} m`
+                      formatTrainingDistance(session.distanceCm)
                     }
                   </p>
                 </div>

--- a/src/components/Vision/Training/TrainingSession.tsx
+++ b/src/components/Vision/Training/TrainingSession.tsx
@@ -73,6 +73,14 @@ export default function TrainingSession({
   const difficulty = DIFFICULTY_LEVELS[currentLevel - 1] || DIFFICULTY_LEVELS[0]
   const accuracy = attempts > 0 ? (correct / attempts) * 100 : 0
   const currentGlassesStage = READER_GLASSES_STAGES[readerGlassesStage] || READER_GLASSES_STAGES[0]
+  const minTrainingDistanceCm = deviceMode === 'desktop' ? 60 : 20
+  const maxTrainingDistanceCm = deviceMode === 'desktop' ? 100 : 60
+  const clampDistanceForDevice = (distanceCm: number) => {
+    return Math.min(maxTrainingDistanceCm, Math.max(minTrainingDistanceCm, distanceCm))
+  }
+  const trainingDistanceCm = distanceProgressionMode
+    ? clampDistanceForDevice(targetDistanceCm)
+    : clampDistanceForDevice(difficulty.targetDistance)
 
   // Reset target distance if device mode changes
   useEffect(() => {
@@ -217,7 +225,7 @@ export default function TrainingSession({
         body: JSON.stringify({
           visionType,
           exerciseType,
-          distanceCm: distanceProgressionMode ? targetDistanceCm : difficulty.targetDistance,
+          distanceCm: trainingDistanceCm,
           accuracy,
           level: difficulty.label,
           duration: sessionDuration,
@@ -302,9 +310,9 @@ export default function TrainingSession({
               }}
               onDistanceAdjust={(direction) => {
                 if (direction === 'further') {
-                  setTargetDistanceCm(prev => Math.min(prev + 1, 100))
+                  setTargetDistanceCm(prev => clampDistanceForDevice(prev + 1))
                 } else {
-                  setTargetDistanceCm(prev => Math.max(prev - 1, 15))
+                  setTargetDistanceCm(prev => clampDistanceForDevice(prev - 1))
                 }
               }}
             />
@@ -321,9 +329,9 @@ export default function TrainingSession({
               }}
               onDistanceAdjust={(direction) => {
                 if (direction === 'further') {
-                  setTargetDistanceCm(prev => Math.min(prev + 1, 100))
+                  setTargetDistanceCm(prev => clampDistanceForDevice(prev + 1))
                 } else {
-                  setTargetDistanceCm(prev => Math.max(prev - 1, 15))
+                  setTargetDistanceCm(prev => clampDistanceForDevice(prev - 1))
                 }
               }}
             />
@@ -399,7 +407,7 @@ export default function TrainingSession({
       )}
 
       {/* Distance Progression Panel - for near vision training - hide when active */}
-      {!isActive && visionType === 'near' && distanceProgressionMode && (
+      {!isActive && deviceMode === 'phone' && visionType === 'near' && distanceProgressionMode && (
         <div className="bg-gradient-to-r from-blue-600/20 to-cyan-600/20 border border-blue-400/30 rounded-lg p-5">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-3">
@@ -428,12 +436,14 @@ export default function TrainingSession({
             <div className="bg-gray-700 rounded-full h-4 overflow-hidden">
               <div
                 className="h-full bg-gradient-to-r from-blue-500 to-cyan-400 transition-all duration-500"
-                style={{ width: `${((targetDistanceCm - 20) / 40) * 100}%` }}
+                style={{
+                  width: `${((trainingDistanceCm - minTrainingDistanceCm) / (maxTrainingDistanceCm - minTrainingDistanceCm)) * 100}%`
+                }}
               />
             </div>
             <div className="flex justify-between text-xs text-gray-500 mt-1">
-              <span>20 cm (close)</span>
-              <span>60 cm (arm's length)</span>
+              <span>{minTrainingDistanceCm} cm (close)</span>
+              <span>{maxTrainingDistanceCm} cm (arm's length)</span>
             </div>
           </div>
 
@@ -498,7 +508,7 @@ export default function TrainingSession({
       {/* Distance guidance - hide when active to keep chart visible */}
       {!isActive && (
         <DistanceGuidance
-          targetDistanceCm={distanceProgressionMode ? targetDistanceCm : difficulty.targetDistance}
+          targetDistanceCm={trainingDistanceCm}
           visionType={visionType}
           deviceMode={deviceMode}
         />

--- a/src/components/Vision/VisionTraining.tsx
+++ b/src/components/Vision/VisionTraining.tsx
@@ -1,26 +1,39 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useEffect, useState, type ComponentType, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import {
-  Play,
-  Eye,
-  BookOpen,
-  Flame,
   Award,
-  Smartphone,
+  BarChart3,
+  BookOpen,
+  Calendar,
+  Eye,
+  Flame,
   Monitor,
-  RotateCcw
+  Play,
+  RotateCcw,
+  Smartphone,
+  Zap
 } from 'lucide-react'
 import { PortalHeader } from '@/components/Navigation/PortalHeader'
 import CurriculumOverview from './Training/CurriculumOverview'
 import DailyPractice from './Training/DailyPractice'
+import ProgramProgress from './Training/ProgramProgress'
+import ProgressDashboard from './Training/ProgressDashboard'
 import QuickPractice from './Training/QuickPractice'
 import TrainingSession from './Training/TrainingSession'
 
-type TabMode = 'today' | 'trainer' | 'exercises'
+type TabMode = 'curriculum' | 'today' | 'practice' | 'trainer' | 'progress'
+
+interface TabConfig {
+  id: TabMode
+  label: string
+  icon: ComponentType<{ className?: string }>
+  enrolledOnly?: boolean
+}
 
 interface EnrollmentData {
+  startDate: string
   currentWeek: number
   currentDay: number
   sessionsCompleted: number
@@ -36,6 +49,14 @@ interface EnrollmentData {
   }
 }
 
+interface CompletedSession {
+  week: number
+  day: number
+  sessionTitle: string
+  completedAt: string
+  localDate: string
+}
+
 interface TodaySessionData {
   week: number
   day: number
@@ -49,15 +70,60 @@ interface TodaySessionData {
   } | null
 }
 
+const DEFAULT_PHASE_PROGRESS = {
+  phase1: false,
+  phase2: false,
+  phase3: false,
+  phase4: false,
+  phase5: false,
+  phase6: false
+}
+
+const BASE_TABS: TabConfig[] = [
+  { id: 'curriculum', label: 'Curriculum', icon: Calendar },
+  { id: 'today', label: "Today's Session", icon: Play, enrolledOnly: true },
+  { id: 'practice', label: 'Quick Practice', icon: Zap },
+  { id: 'trainer', label: 'Snellen Trainer', icon: Eye },
+  { id: 'progress', label: 'Progress', icon: BarChart3, enrolledOnly: true }
+]
+
+function mapCompletedSessions(sessions: any[] = []): CompletedSession[] {
+  return sessions
+    .map((session) => ({
+      week: Number(session.week || 0),
+      day: Number(session.day || 0),
+      sessionTitle: session.sessionTitle || `Week ${session.week} Day ${session.day}`,
+      completedAt: session.completedAt || '',
+      localDate: session.localDate || ''
+    }))
+    .filter((session) => session.week > 0 && session.day > 0)
+}
+
+function TabPanel({
+  active,
+  children,
+  className = ''
+}: {
+  active: boolean
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <div className={`${active ? 'block' : 'hidden'} ${className}`}>
+      {children}
+    </div>
+  )
+}
+
 export function VisionTraining() {
-  const [activeTab, setActiveTab] = useState<TabMode>('today')
+  const [activeTab, setActiveTab] = useState<TabMode>('curriculum')
   const [isEnrolled, setIsEnrolled] = useState(false)
   const [enrolling, setEnrolling] = useState(false)
   const [loading, setLoading] = useState(true)
   const [enrollmentData, setEnrollmentData] = useState<EnrollmentData | null>(null)
   const [todaySession, setTodaySession] = useState<TodaySessionData | null>(null)
+  const [completedSessions, setCompletedSessions] = useState<CompletedSession[]>([])
 
-  // Trainer settings
   const [trainerVisionType, setTrainerVisionType] = useState<'near' | 'far'>('near')
   const [trainerExerciseType, setTrainerExerciseType] = useState<'letters' | 'e-directional'>('letters')
   const [trainerDeviceMode, setTrainerDeviceMode] = useState<'phone' | 'desktop'>('phone')
@@ -65,7 +131,6 @@ export function VisionTraining() {
   const [untimedMode, setUntimedMode] = useState(false)
   const [isTrainingActive, setIsTrainingActive] = useState(false)
 
-  // Dispatch binocular training mode events for hiding UI elements
   useEffect(() => {
     const isBinocularMode = isTrainingActive && binocularMode !== 'off'
     const event = new CustomEvent('binocular-training-mode', { detail: { active: isBinocularMode } })
@@ -76,10 +141,9 @@ export function VisionTraining() {
     checkEnrollment()
   }, [])
 
-  // Handle ESC key to exit binocular training
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isTrainingActive && binocularMode !== 'off') {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isTrainingActive && binocularMode !== 'off') {
         setIsTrainingActive(false)
       }
     }
@@ -87,24 +151,36 @@ export function VisionTraining() {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [isTrainingActive, binocularMode])
 
-  const checkEnrollment = async () => {
+  const checkEnrollment = async (options: { preserveTab?: boolean; switchToToday?: boolean } = {}) => {
     try {
       const response = await fetch('/api/vision/program')
       const data = await response.json()
+
       if (data.success && data.enrolled) {
         setIsEnrolled(true)
         setEnrollmentData({
+          startDate: data.enrollment.startDate,
           currentWeek: data.enrollment.currentWeek || data.todaySession?.week || 1,
           currentDay: data.enrollment.currentDay || data.todaySession?.day || 1,
           sessionsCompleted: data.enrollment.sessionsCompleted || 0,
           totalPracticeMinutes: data.enrollment.totalPracticeMinutes || 0,
           streakDays: data.enrollment.streakDays || 0,
-          phaseProgress: data.enrollment.phaseProgress || {
-            phase1: false, phase2: false, phase3: false,
-            phase4: false, phase5: false, phase6: false
-          }
+          phaseProgress: data.enrollment.phaseProgress || DEFAULT_PHASE_PROGRESS
         })
-        setTodaySession(data.todaySession)
+        setTodaySession(data.todaySession || null)
+        setCompletedSessions(mapCompletedSessions(data.recentSessions || []))
+
+        if (options.switchToToday) {
+          setActiveTab('today')
+        } else if (!options.preserveTab) {
+          setActiveTab((current) => (current === 'curriculum' ? 'today' : current))
+        }
+      } else if (data.success) {
+        setIsEnrolled(false)
+        setEnrollmentData(null)
+        setTodaySession(null)
+        setCompletedSessions([])
+        setActiveTab((current) => (current === 'today' || current === 'progress' ? 'curriculum' : current))
       }
     } catch (error) {
       console.error('Failed to check enrollment:', error)
@@ -124,7 +200,8 @@ export function VisionTraining() {
       const data = await response.json()
       if (data.success) {
         setIsEnrolled(true)
-        checkEnrollment()
+        setActiveTab('today')
+        await checkEnrollment({ switchToToday: true })
       }
     } catch (error) {
       console.error('Failed to enroll:', error)
@@ -133,15 +210,37 @@ export function VisionTraining() {
     }
   }
 
+  const handleMarkPastComplete = async (week: number, day: number, localDate?: string) => {
+    const response = await fetch('/api/vision/program', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        action: 'complete_past_session',
+        data: { week, day, localDate }
+      })
+    })
+    const data = await response.json()
+    if (!data.success) {
+      throw new Error(data.error || 'Failed to make up lesson')
+    }
+    await checkEnrollment({ preserveTab: true })
+  }
+
+  const handleStartSession = () => {
+    setActiveTab('today')
+  }
+
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-gray-900 to-gray-800"
+      <div
+        className="min-h-screen bg-gradient-to-br from-gray-900 to-gray-800"
         style={{
           backgroundImage: 'linear-gradient(rgba(0,0,0,0.7), rgba(0,0,0,0.8)), url(/hero-background.jpg)',
           backgroundSize: 'cover',
           backgroundPosition: 'center',
           backgroundAttachment: 'fixed'
-        }}>
+        }}
+      >
         <div className="min-h-screen flex items-center justify-center">
           <div className="text-center">
             <div className="w-12 h-12 border-4 border-primary-400/30 border-t-primary-400 rounded-full animate-spin mx-auto mb-4" />
@@ -152,30 +251,23 @@ export function VisionTraining() {
     )
   }
 
-  // Calculate progress
-  const progressPercent = enrollmentData
-    ? ((enrollmentData.currentWeek - 1) * 5 + enrollmentData.currentDay) / 60 * 100
+  const visibleTabs = BASE_TABS.filter((tab) => isEnrolled || !tab.enrolledOnly)
+  const progressDay = enrollmentData
+    ? (enrollmentData.currentWeek - 1) * 5 + Math.min(enrollmentData.currentDay, 5)
     : 0
-
-  // Build tabs - dynamic first tab label based on enrollment
-  const tabs = [
-    {
-      id: 'today' as TabMode,
-      label: isEnrolled ? "Today's Session" : "Get Started",
-      icon: Play
-    },
-    { id: 'trainer' as TabMode, label: 'Focus Training', icon: Eye },
-    { id: 'exercises' as TabMode, label: 'Vision Library', icon: BookOpen },
-  ]
+  const progressPercent = enrollmentData ? (progressDay / 60) * 100 : 0
+  const isBinocularOverlayActive = isTrainingActive && binocularMode !== 'off'
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 to-gray-800"
+    <div
+      className="min-h-screen bg-gradient-to-br from-gray-900 to-gray-800"
       style={{
         backgroundImage: 'linear-gradient(rgba(0,0,0,0.7), rgba(0,0,0,0.8)), url(/hero-background.jpg)',
         backgroundSize: 'cover',
         backgroundPosition: 'center',
         backgroundAttachment: 'fixed'
-      }}>
+      }}
+    >
       <div className="relative z-10 min-h-screen flex flex-col pt-28">
         <PortalHeader
           section="Vision Training"
@@ -183,310 +275,292 @@ export function VisionTraining() {
           secondaryBackText="Daily History"
         />
 
-        {/* Page Title — compact on mobile */}
-        <div className="text-center py-2">
-          <h2 className="text-2xl md:text-4xl font-bold text-white mb-0">
-            <Eye className="inline-block w-6 h-6 md:w-8 md:h-8 mr-1 text-primary-400" />
-            <span className="text-primary-400">Vision</span> Training
-          </h2>
-        </div>
-
-        {/* Tab Navigation - 3 tabs only */}
-        <div className="flex justify-center gap-2 md:gap-4 mb-3 md:mb-6 px-4">
-          {tabs.map(tab => {
+        <div className="flex justify-center gap-2 md:gap-4 mb-4 md:mb-6 px-4 pt-4 flex-wrap">
+          {visibleTabs.map((tab) => {
             const Icon = tab.icon
             const isActive = activeTab === tab.id
             return (
               <button
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
-                className={`px-4 md:px-6 py-3 rounded-lg font-semibold transition-all duration-300 flex items-center gap-2 ${isActive
-                  ? 'bg-primary-600 text-white shadow-lg shadow-primary-500/20'
-                  : 'bg-gray-800/30 backdrop-blur-sm text-gray-300 hover:bg-gray-700/30'
+                className={`px-4 md:px-6 py-3 rounded-lg font-semibold transition-all duration-300 flex items-center gap-2 min-h-[48px] ${
+                  isActive
+                    ? 'bg-primary-600 text-white shadow-lg shadow-primary-500/20'
+                    : 'bg-gray-800/30 backdrop-blur-sm text-gray-300 hover:bg-gray-700/30'
                 }`}
               >
-                <Icon className="w-5 h-5" />
+                <Icon className="w-5 h-5 shrink-0" />
                 <span className="hidden sm:inline">{tab.label}</span>
+                <span className="sm:hidden">{tab.label.split(' ')[0]}</span>
               </button>
             )
           })}
         </div>
 
-        {/* Tab Content */}
-        <div className={`mx-auto pb-12 flex-1 ${isTrainingActive && binocularMode !== 'off' ? 'px-2 w-full' : 'container px-4'}`}>
-          <div className={isTrainingActive && binocularMode !== 'off' ? 'w-full' : 'max-w-6xl mx-auto'}>
+        <div className={`mx-auto pb-12 flex-1 ${isBinocularOverlayActive ? 'px-2 w-full' : 'container px-4'}`}>
+          <div className={isBinocularOverlayActive ? 'w-full' : 'max-w-6xl mx-auto'}>
+            <TabPanel active={activeTab === 'curriculum'} className="space-y-4">
+              {isEnrolled && enrollmentData ? (
+                <ProgramProgress
+                  enrollment={enrollmentData}
+                  completedSessions={completedSessions}
+                  onMarkComplete={handleMarkPastComplete}
+                  onStartSession={handleStartSession}
+                />
+              ) : (
+                <CurriculumOverview onEnroll={handleEnroll} enrolling={enrolling} />
+              )}
+            </TabPanel>
 
-            {/* TODAY'S SESSION / GET STARTED TAB */}
-            {activeTab === 'today' && (
-              <div className="space-y-4">
-                {isEnrolled && enrollmentData && todaySession ? (
-                  <>
-                    {/* Compact Progress Bar */}
-                    <div className="bg-gradient-to-br from-gray-800/60 to-gray-900/60 backdrop-blur-sm rounded-xl p-4 border border-primary-400/20">
-                      <div className="flex items-center justify-between mb-2">
-                        <div className="flex items-center gap-3">
-                          <span className="text-white font-semibold">
-                            Week {enrollmentData.currentWeek} of 12
-                          </span>
-                          <span className="text-xs px-2 py-0.5 bg-primary-500/20 text-primary-300 rounded">
-                            {todaySession.phase}
-                          </span>
+            {isEnrolled && (
+              <TabPanel active={activeTab === 'today'} className="space-y-4">
+                {enrollmentData && todaySession && (
+                  <div className="bg-gradient-to-br from-gray-800/60 to-gray-900/60 backdrop-blur-sm rounded-xl p-4 border border-primary-400/20">
+                    <div className="flex items-center justify-between mb-2 gap-3">
+                      <div className="flex items-center gap-3 flex-wrap">
+                        <span className="text-white font-semibold">
+                          Week {enrollmentData.currentWeek} of 12
+                        </span>
+                        <span className="text-xs px-2 py-0.5 bg-primary-500/20 text-primary-300 rounded">
+                          {todaySession.phase}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-4 text-sm">
+                        <div className="flex items-center gap-1">
+                          <Flame className="w-4 h-4 text-orange-400" />
+                          <span className="text-white font-semibold">{enrollmentData.streakDays}</span>
                         </div>
-                        <div className="flex items-center gap-4 text-sm">
-                          <div className="flex items-center gap-1">
-                            <Flame className="w-4 h-4 text-orange-400" />
-                            <span className="text-white font-semibold">{enrollmentData.streakDays}</span>
-                          </div>
-                          <div className="flex items-center gap-1">
-                            <Award className="w-4 h-4 text-secondary-400" />
-                            <span className="text-white font-semibold">{enrollmentData.sessionsCompleted}</span>
-                          </div>
-                        </div>
-                      </div>
-                      <div className="bg-gray-700 rounded-full h-2 overflow-hidden">
-                        <div
-                          className="h-full bg-gradient-to-r from-primary-500 to-secondary-500 transition-all duration-500"
-                          style={{ width: `${progressPercent}%` }}
-                        />
-                      </div>
-                      <div className="flex justify-between text-xs text-gray-500 mt-1">
-                        <span>Day {(enrollmentData.currentWeek - 1) * 5 + Math.min(enrollmentData.currentDay, 5)} of 60</span>
-                        <span>{progressPercent.toFixed(0)}%</span>
-                      </div>
-                    </div>
-
-                    {/* Daily Practice Component (has session content + progress summary) */}
-                    <DailyPractice />
-                  </>
-                ) : (
-                  /* Not Enrolled - Show Curriculum Overview with enrollment */
-                  <CurriculumOverview onEnroll={handleEnroll} enrolling={enrolling} />
-                )}
-              </div>
-            )}
-
-            {/* FOCUS TRAINING TAB (renamed from Snellen Trainer) */}
-            {activeTab === 'trainer' && (
-              <div className="space-y-4">
-                {/* Settings card - ONLY show when NOT training */}
-                {!isTrainingActive && (
-                  <div className="bg-gradient-to-br from-gray-800/80 to-gray-900/80 backdrop-blur-sm rounded-xl p-4 sm:p-6 border border-primary-400/20 shadow-lg">
-                    {/* Header with inline Start Training */}
-                    <div className="flex items-start justify-between gap-3 mb-3">
-                      <div>
-                        <h3 className="text-xl sm:text-2xl font-bold text-white flex items-center gap-2">
-                          <Eye className="w-5 h-5 sm:w-6 sm:h-6 text-primary-400" />
-                          Focus Training
-                        </h3>
-                        <p className="text-gray-300 mt-1 text-xs sm:text-sm">
-                          Train at your edge of clarity - where text is just barely readable.
-                        </p>
-                      </div>
-                      <button
-                        onClick={() => setIsTrainingActive(true)}
-                        className="bg-gradient-to-r from-secondary-500 to-secondary-600 hover:from-secondary-600 hover:to-secondary-700 text-white px-6 py-3 rounded-xl font-bold text-lg flex items-center gap-2 shadow-lg shadow-secondary-500/30 hover:scale-105 active:scale-95 transition-all whitespace-nowrap"
-                      >
-                        <Play className="w-5 h-5" />
-                        Start Training
-                      </button>
-                    </div>
-
-                    {/* Settings grid — stacks on mobile, 3-col on desktop */}
-                    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4 mb-3">
-                      {/* Device Mode */}
-                      <div>
-                        <label className="block text-sm font-medium text-gray-300 mb-2">Device Mode</label>
-                        <div className="flex gap-2">
-                          <button
-                            onClick={() => setTrainerDeviceMode('phone')}
-                            className={`flex-1 py-2 px-3 rounded-lg font-medium transition-all flex items-center justify-center gap-2 text-sm ${
-                              trainerDeviceMode === 'phone'
-                                ? 'bg-primary-600 text-white shadow-md shadow-primary-500/30'
-                                : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
-                            }`}
-                          >
-                            <Smartphone className="w-4 h-4" />
-                            Phone
-                          </button>
-                          <button
-                            onClick={() => setTrainerDeviceMode('desktop')}
-                            className={`flex-1 py-2 px-3 rounded-lg font-medium transition-all flex items-center justify-center gap-2 text-sm ${
-                              trainerDeviceMode === 'desktop'
-                                ? 'bg-primary-600 text-white shadow-md shadow-primary-500/30'
-                                : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
-                            }`}
-                          >
-                            <Monitor className="w-4 h-4" />
-                            Desktop
-                          </button>
-                        </div>
-                      </div>
-
-                      {/* Training Focus */}
-                      <div>
-                        <label className="block text-sm font-medium text-gray-300 mb-2">Training Focus</label>
-                        <div className="flex gap-2">
-                          <button
-                            onClick={() => setTrainerVisionType('near')}
-                            className={`flex-1 py-2 px-2 sm:px-3 rounded-lg font-medium transition-all flex items-center justify-center gap-1 sm:gap-2 text-xs sm:text-sm ${
-                              trainerVisionType === 'near'
-                                ? 'bg-emerald-600 text-white shadow-md shadow-emerald-500/30'
-                                : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
-                            }`}
-                          >
-                            <Eye className="w-4 h-4 shrink-0" />
-                            <span className="sm:hidden">Near</span>
-                            <span className="hidden sm:inline">Nearsighted</span>
-                          </button>
-                          <button
-                            onClick={() => setTrainerVisionType('far')}
-                            className={`flex-1 py-2 px-2 sm:px-3 rounded-lg font-medium transition-all flex items-center justify-center gap-1 sm:gap-2 text-xs sm:text-sm ${
-                              trainerVisionType === 'far'
-                                ? 'bg-emerald-600 text-white shadow-md shadow-emerald-500/30'
-                                : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
-                            }`}
-                          >
-                            <Eye className="w-4 h-4 shrink-0" />
-                            <span className="sm:hidden">Far</span>
-                            <span className="hidden sm:inline">Farsighted</span>
-                          </button>
-                        </div>
-                      </div>
-
-                      {/* Chart Type — full width on 2-col mobile */}
-                      <div className="col-span-2 sm:col-span-1">
-                        <label className="block text-sm font-medium text-gray-300 mb-2">Chart Type</label>
-                        <div className="flex gap-2">
-                          <button
-                            onClick={() => setTrainerExerciseType('letters')}
-                            className={`flex-1 py-2 px-3 rounded-lg font-bold transition-all text-base ${
-                              trainerExerciseType === 'letters'
-                                ? 'bg-secondary-600 text-white shadow-md shadow-secondary-500/30'
-                                : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
-                            }`}
-                          >
-                            ABC
-                          </button>
-                          <button
-                            onClick={() => setTrainerExerciseType('e-directional')}
-                            className={`flex-1 py-2 px-3 rounded-lg font-bold transition-all text-base ${
-                              trainerExerciseType === 'e-directional'
-                                ? 'bg-secondary-600 text-white shadow-md shadow-secondary-500/30'
-                                : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
-                            }`}
-                          >
-                            E →
-                          </button>
+                        <div className="flex items-center gap-1">
+                          <Award className="w-4 h-4 text-secondary-400" />
+                          <span className="text-white font-semibold">{enrollmentData.sessionsCompleted}</span>
                         </div>
                       </div>
                     </div>
-
-                    {/* Dynamic info text */}
-                    <p className="text-xs sm:text-sm text-gray-400 mb-3">
-                      {trainerVisionType === 'near' ? 'Myopic: push clarity outward' : 'Hyperopic: pull clarity inward'}
-                    </p>
-
-                    {/* Binocular Training Mode */}
-                    <div className="border-t border-gray-700/30 pt-3">
-                      <div className="flex items-center justify-between mb-2">
-                        <label className="text-sm font-medium text-gray-300">Binocular Training</label>
-                        <span className="text-[10px] text-gray-500">hold phone in landscape</span>
-                      </div>
-                      <div className="grid grid-cols-3 gap-2">
-                        {([
-                          { value: 'off' as const, label: 'Off', desc: 'Single chart' },
-                          { value: 'duplicate' as const, label: 'Duplicate', desc: 'Identical pair' },
-                          { value: 'redgreen' as const, label: 'Red/Green', desc: 'Color split' },
-                          { value: 'grid-square' as const, label: 'Grid \u25A1', desc: 'Square grid' },
-                          { value: 'grid-slanted' as const, label: 'Grid \u25C7', desc: 'Diagonal grid' },
-                          { value: 'alternating' as const, label: 'Alternating', desc: 'Fill-in fusion' },
-                        ]).map(opt => (
-                          <button
-                            key={opt.value}
-                            onClick={() => setBinocularMode(opt.value)}
-                            className={`py-2 px-3 rounded-lg font-medium transition-all text-center ${
-                              binocularMode === opt.value
-                                ? 'bg-orange-600 text-white shadow-md shadow-orange-500/30'
-                                : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
-                            }`}
-                          >
-                            <div className="text-xs font-semibold">{opt.label}</div>
-                            <div className="text-[10px] opacity-70 mt-0.5">{opt.desc}</div>
-                          </button>
-                        ))}
-                      </div>
+                    <div className="bg-gray-700 rounded-full h-2 overflow-hidden">
+                      <div
+                        className="h-full bg-gradient-to-r from-primary-500 to-secondary-500 transition-all duration-500"
+                        style={{ width: `${progressPercent}%` }}
+                      />
                     </div>
-
-                    {/* Untimed mode toggle */}
-                    <div className="border-t border-gray-700/30 pt-3 mt-3">
-                      <button
-                        onClick={() => setUntimedMode(!untimedMode)}
-                        className="flex items-center justify-between w-full"
-                      >
-                        <div>
-                          <span className="text-sm font-medium text-gray-300">Free Practice</span>
-                          <p className="text-[10px] text-gray-500 mt-0.5">No level timer, no forced resets — just train</p>
-                        </div>
-                        <div className={`w-11 h-6 rounded-full transition-all relative ${
-                          untimedMode ? 'bg-secondary-500' : 'bg-gray-600'
-                        }`}>
-                          <div className={`absolute top-0.5 w-5 h-5 rounded-full bg-white shadow transition-all ${
-                            untimedMode ? 'left-[22px]' : 'left-0.5'
-                          }`} />
-                        </div>
-                      </button>
+                    <div className="flex justify-between text-xs text-gray-500 mt-1">
+                      <span>Day {progressDay} of 60</span>
+                      <span>{progressPercent.toFixed(0)}%</span>
                     </div>
                   </div>
                 )}
-
-                {/* Training Session - ONLY show when training is active */}
-                {isTrainingActive && binocularMode !== 'off' ? (
-                  typeof window !== 'undefined' ? createPortal(
-                    /* Fullscreen overlay for binocular — hides navbars and microphone */
-                    <div className="fixed inset-0 w-full h-full z-[99999] bg-gray-900 flex flex-col overflow-hidden">
-                      <div className="flex-1 flex flex-col">
-                        <TrainingSession
-                          visionType={trainerVisionType}
-                          exerciseType={trainerExerciseType}
-                          deviceMode={trainerDeviceMode}
-                          binocularMode={binocularMode}
-                          untimed={untimedMode}
-                          onExit={() => setIsTrainingActive(false)}
-                          onActiveChange={(active) => {
-                            if (!active) setIsTrainingActive(false)
-                          }}
-                        />
-                      </div>
-                    </div>,
-                    document.body
-                  ) : null
-                ) : isTrainingActive ? (
-                  <div className="space-y-4">
-                    <button
-                      onClick={() => setIsTrainingActive(false)}
-                      className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
-                    >
-                      <RotateCcw className="w-4 h-4" />
-                      Back to Settings
-                    </button>
-                    <TrainingSession
-                      visionType={trainerVisionType}
-                      exerciseType={trainerExerciseType}
-                      deviceMode={trainerDeviceMode}
-                      binocularMode={binocularMode}
-                      untimed={untimedMode}
-                      onActiveChange={(active) => {
-                        if (!active) setIsTrainingActive(false)
-                      }}
-                    />
-                  </div>
-                ) : null}
-              </div>
+                <DailyPractice />
+              </TabPanel>
             )}
 
-            {/* VISION LIBRARY TAB (renamed from Quick Exercises) */}
-            {activeTab === 'exercises' && (
+            <TabPanel active={activeTab === 'practice'}>
               <QuickPractice />
+            </TabPanel>
+
+            <TabPanel active={activeTab === 'trainer'} className="space-y-4">
+              {!isTrainingActive && (
+                <div className="bg-gradient-to-br from-gray-800/80 to-gray-900/80 backdrop-blur-sm rounded-xl p-4 sm:p-6 border border-primary-400/20 shadow-lg">
+                  <div className="flex items-start justify-between gap-3 mb-3">
+                    <div>
+                      <h2 className="text-xl sm:text-2xl font-bold text-white flex items-center gap-2">
+                        <Eye className="w-5 h-5 sm:w-6 sm:h-6 text-primary-400" />
+                        Snellen Trainer
+                      </h2>
+                      <p className="text-gray-300 mt-1 text-xs sm:text-sm">
+                        Train at your edge of clarity where text is just barely readable.
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => setIsTrainingActive(true)}
+                      className="bg-gradient-to-r from-secondary-500 to-secondary-600 hover:from-secondary-600 hover:to-secondary-700 text-white px-6 py-3 rounded-xl font-bold text-lg flex items-center gap-2 shadow-lg shadow-secondary-500/30 hover:scale-105 active:scale-95 transition-all whitespace-nowrap"
+                    >
+                      <Play className="w-5 h-5" />
+                      Start
+                    </button>
+                  </div>
+
+                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4 mb-3">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-300 mb-2">Device Mode</label>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => setTrainerDeviceMode('phone')}
+                          className={`flex-1 py-2 px-3 rounded-lg font-medium transition-all flex items-center justify-center gap-2 text-sm ${
+                            trainerDeviceMode === 'phone'
+                              ? 'bg-primary-600 text-white shadow-md shadow-primary-500/30'
+                              : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
+                          }`}
+                        >
+                          <Smartphone className="w-4 h-4" />
+                          Phone
+                        </button>
+                        <button
+                          onClick={() => setTrainerDeviceMode('desktop')}
+                          className={`flex-1 py-2 px-3 rounded-lg font-medium transition-all flex items-center justify-center gap-2 text-sm ${
+                            trainerDeviceMode === 'desktop'
+                              ? 'bg-primary-600 text-white shadow-md shadow-primary-500/30'
+                              : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
+                          }`}
+                        >
+                          <Monitor className="w-4 h-4" />
+                          Desktop
+                        </button>
+                      </div>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-300 mb-2">Training Focus</label>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => setTrainerVisionType('near')}
+                          className={`flex-1 py-2 px-2 sm:px-3 rounded-lg font-medium transition-all flex items-center justify-center gap-1 sm:gap-2 text-xs sm:text-sm ${
+                            trainerVisionType === 'near'
+                              ? 'bg-emerald-600 text-white shadow-md shadow-emerald-500/30'
+                              : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
+                          }`}
+                        >
+                          <Eye className="w-4 h-4 shrink-0" />
+                          <span>Near</span>
+                        </button>
+                        <button
+                          onClick={() => setTrainerVisionType('far')}
+                          className={`flex-1 py-2 px-2 sm:px-3 rounded-lg font-medium transition-all flex items-center justify-center gap-1 sm:gap-2 text-xs sm:text-sm ${
+                            trainerVisionType === 'far'
+                              ? 'bg-emerald-600 text-white shadow-md shadow-emerald-500/30'
+                              : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
+                          }`}
+                        >
+                          <Eye className="w-4 h-4 shrink-0" />
+                          <span>Far</span>
+                        </button>
+                      </div>
+                    </div>
+
+                    <div className="col-span-2 sm:col-span-1">
+                      <label className="block text-sm font-medium text-gray-300 mb-2">Chart Type</label>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => setTrainerExerciseType('letters')}
+                          className={`flex-1 py-2 px-3 rounded-lg font-bold transition-all text-base ${
+                            trainerExerciseType === 'letters'
+                              ? 'bg-secondary-600 text-white shadow-md shadow-secondary-500/30'
+                              : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
+                          }`}
+                        >
+                          ABC
+                        </button>
+                        <button
+                          onClick={() => setTrainerExerciseType('e-directional')}
+                          className={`flex-1 py-2 px-3 rounded-lg font-bold transition-all text-base ${
+                            trainerExerciseType === 'e-directional'
+                              ? 'bg-secondary-600 text-white shadow-md shadow-secondary-500/30'
+                              : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
+                          }`}
+                        >
+                          E
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+
+                  <p className="text-xs sm:text-sm text-gray-400 mb-3">
+                    {trainerVisionType === 'near' ? 'Myopic: push clarity outward' : 'Hyperopic: pull clarity inward'}
+                  </p>
+
+                  <div className="border-t border-gray-700/30 pt-3">
+                    <div className="flex items-center justify-between mb-2">
+                      <label className="text-sm font-medium text-gray-300">Binocular Training</label>
+                      <span className="text-[10px] text-gray-500">hold phone in landscape</span>
+                    </div>
+                    <div className="grid grid-cols-3 gap-2">
+                      {([
+                        { value: 'off' as const, label: 'Off', desc: 'Single chart' },
+                        { value: 'duplicate' as const, label: 'Duplicate', desc: 'Identical pair' },
+                        { value: 'redgreen' as const, label: 'Red/Green', desc: 'Color split' },
+                        { value: 'grid-square' as const, label: 'Grid SQ', desc: 'Square grid' },
+                        { value: 'grid-slanted' as const, label: 'Grid DI', desc: 'Diagonal grid' },
+                        { value: 'alternating' as const, label: 'Alternating', desc: 'Fill-in fusion' }
+                      ]).map((option) => (
+                        <button
+                          key={option.value}
+                          onClick={() => setBinocularMode(option.value)}
+                          className={`py-2 px-3 rounded-lg font-medium transition-all text-center ${
+                            binocularMode === option.value
+                              ? 'bg-orange-600 text-white shadow-md shadow-orange-500/30'
+                              : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
+                          }`}
+                        >
+                          <div className="text-xs font-semibold">{option.label}</div>
+                          <div className="text-[10px] opacity-70 mt-0.5">{option.desc}</div>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="border-t border-gray-700/30 pt-3 mt-3">
+                    <button
+                      onClick={() => setUntimedMode(!untimedMode)}
+                      className="flex items-center justify-between w-full"
+                    >
+                      <div>
+                        <span className="text-sm font-medium text-gray-300">Free Practice</span>
+                        <p className="text-[10px] text-gray-500 mt-0.5">No level timer, no forced resets; just train</p>
+                      </div>
+                      <div className={`w-11 h-6 rounded-full transition-all relative ${untimedMode ? 'bg-secondary-500' : 'bg-gray-600'}`}>
+                        <div className={`absolute top-0.5 w-5 h-5 rounded-full bg-white shadow transition-all ${untimedMode ? 'left-[22px]' : 'left-0.5'}`} />
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {isTrainingActive && binocularMode !== 'off' ? (
+                typeof window !== 'undefined'
+                  ? createPortal(
+                      <div className="fixed inset-0 w-full h-full z-[99999] bg-gray-900 flex flex-col overflow-hidden">
+                        <div className="flex-1 flex flex-col">
+                          <TrainingSession
+                            visionType={trainerVisionType}
+                            exerciseType={trainerExerciseType}
+                            deviceMode={trainerDeviceMode}
+                            binocularMode={binocularMode}
+                            untimed={untimedMode}
+                            onExit={() => setIsTrainingActive(false)}
+                            onActiveChange={(active) => {
+                              if (!active) setIsTrainingActive(false)
+                            }}
+                          />
+                        </div>
+                      </div>,
+                      document.body
+                    )
+                  : null
+              ) : isTrainingActive ? (
+                <div className="space-y-4">
+                  <button
+                    onClick={() => setIsTrainingActive(false)}
+                    className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
+                  >
+                    <RotateCcw className="w-4 h-4" />
+                    Back to Settings
+                  </button>
+                  <TrainingSession
+                    visionType={trainerVisionType}
+                    exerciseType={trainerExerciseType}
+                    deviceMode={trainerDeviceMode}
+                    binocularMode={binocularMode}
+                    untimed={untimedMode}
+                    onActiveChange={(active) => {
+                      if (!active) setIsTrainingActive(false)
+                    }}
+                  />
+                </div>
+              ) : null}
+            </TabPanel>
+
+            {isEnrolled && (
+              <TabPanel active={activeTab === 'progress'}>
+                <ProgressDashboard />
+              </TabPanel>
             )}
           </div>
         </div>

--- a/src/data/visionExercises.ts
+++ b/src/data/visionExercises.ts
@@ -192,7 +192,7 @@ export const visionExercises: VisionExercise[] = [
     focus: ['gait', 'vision'],
     equipment: ['Printed/onscreen chart'],
     checkpoints: [
-      'Start 2 m from chart, heel-to-toe walk toward/away.',
+      'Start 60-100 cm from the chart, heel-to-toe walk toward/away within reach.',
       'Read next lower line each step.',
       'Switch to E-directional cues midday to vary stimulus.',
     ],
@@ -232,7 +232,7 @@ export const visionExercises: VisionExercise[] = [
       'Change symbol size (large > small) each minute.',
     ],
     guidance: [
-      { heading: 'Distance layering', detail: 'Alternate near (40 cm) vs. far (2 m) projections every loop.' },
+      { heading: 'Distance layering', detail: 'Alternate near (40 cm) vs. desk-distance (90 cm) projections every loop.' },
     ],
     progression: 'Add light head nods on the vertical midline after week 2.',
   },

--- a/src/data/visionProtocols.ts
+++ b/src/data/visionProtocols.ts
@@ -142,8 +142,8 @@ export const visionMetrics = [
   },
   {
     label: 'Far Snellen distance',
-    target: '3 m clear 20/20 line',
-    howTo: 'Use the Snellen trainer or printed chart and log the furthest clean line.',
+    target: '100 cm clear 20/20 line',
+    howTo: 'Use the Snellen trainer or printed chart within reachable desktop distance and log the furthest clean line.',
   },
   {
     label: 'Smooth pursuit stability',


### PR DESCRIPTION
## Summary
- Reworked the live `/vision-training` shell to match the PRD tab model: Curriculum, Today's Session, Quick Practice, Snellen Trainer, and Progress for enrolled users; limited unauthenticated users to Curriculum, Quick Practice, and Snellen Trainer.
- Added `LessonHistory` calendar with completed/missed/today/upcoming status and a persisted "Make up this lesson" flow through the existing additive `complete_past_session` action.
- Scrubbed reachable-distance guidance and runtime distance handling: phone clamps to 20-60 cm, desktop clamps to 60-100 cm, progress/distance displays use centimeters, and old 2-3m/TV-style exercise references are removed.
- Removed the duplicate page-level Vision Training title from the live shell so the page has one portal header and one tab nav.

## Worklist
Closes no issues. Implements jonchyatt/codex-worklist#15.

## Verification
- `npx tsc --noEmit` passed.
- `npm run build` passed; existing local Auth0/env and Next workspace-root warnings only.
- `git diff --check` passed; line-ending warnings only.
- Strict source distance scrub passed: no `2-3m`, standalone `2 m`/`3 m`, `6 ft`, `10 ft`, `TV`, `television`, `across the room`, or meter-formatted training distance text in `src/components/Vision`, `src/data/visionExercises.ts`, or `src/data/visionProtocols.ts`.
- HTTP smoke: `GET /vision-training` returned 200; `/vision-healing` redirected to `/vision-training`.
- Browser smoke on `localhost:3100` passed: unauthenticated tabs render Curriculum/Quick Practice/Snellen Trainer; trainer has separate Device Mode (Phone/Desktop) and Training Focus (Near/Far); Quick Practice tab renders; returning to trainer preserves controls; Start Training renders chart prompt with no old distance language and no current-page console errors.
- Mobile browser smoke at 390px width passed: tabs render as Curriculum/Quick/Snellen with no overflowing visible buttons.

## PRD sections 6-10 checklist
- Section 6 Snellen chart: PASS for render/start smoke in letters mode and trainer controls. Full authenticated database save remains staging-only because local Auth0/DATABASE_URL are unavailable.
- Section 7 Distance progression: PASS for source/runtime distance clamps and scrub; reader-stage unlock mechanics unchanged.
- Section 8 Enrollment flow: PASS for unauthenticated limited tabs and enroll UI presence; authenticated persistence requires staging credentials.
- Section 9 Daily practice: PASS for unchanged DailyPractice integration plus curriculum make-up persistence wiring; authenticated completion requires staging credentials.
- Section 10 Progress dashboard: PASS for Progress tab restoration and history display. Trend charts remain the separate open worklist issue #10.
