### PR TITLE
[worklist#11] Vision Training binocular data collection

### DIFF
--- a/app/api/vision/program/route.ts
+++ b/app/api/vision/program/route.ts
@@ -257,7 +257,17 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: 'Not enrolled in program' }, { status: 400 })
       }
 
-      const { week, day, baselineMinutes, exerciseMinutes, exercisesCompleted, nearSnellenResult, farSnellenResult, notes } = data
+      const {
+        week,
+        day,
+        baselineMinutes,
+        exerciseMinutes,
+        exercisesCompleted,
+        nearSnellenResult,
+        farSnellenResult,
+        binocularResults,
+        notes
+      } = data
 
       // Check if session already completed today
       const todayLocalDate = new Date().toISOString().split('T')[0]
@@ -292,6 +302,7 @@ export async function POST(req: NextRequest) {
           exercisesCompleted: exercisesCompleted || [],
           nearSnellenResult,
           farSnellenResult,
+          binocularResults: binocularResults || null,
           notes,
           localDate: todayLocalDate
         }

--- a/app/api/vision/progress/route.ts
+++ b/app/api/vision/progress/route.ts
@@ -45,6 +45,57 @@ export async function GET(request: Request) {
       take: 20
     })
 
+    const binocularHistory = await prisma.visionSession.findMany({
+      where: { userId: user.id },
+      orderBy: { createdAt: 'desc' },
+      take: 200
+    })
+
+    const binocularSessions = binocularHistory.filter(s => s.binocularMode)
+    const modeBreakdown = binocularSessions.reduce((acc, session) => {
+      const mode = session.binocularMode || 'unknown'
+      const existing = acc[mode] || {
+        mode,
+        bouts: 0,
+        totalSeconds: 0,
+        fusionHeldSeconds: 0,
+        focusCounts: {} as Record<string, number>,
+        deviceCounts: {} as Record<string, number>
+      }
+
+      const duration = session.duration || 0
+      existing.bouts += 1
+      existing.totalSeconds += duration
+      existing.fusionHeldSeconds += session.binocularFusionHeldSeconds || 0
+      if (session.trainingFocus) {
+        existing.focusCounts[session.trainingFocus] = (existing.focusCounts[session.trainingFocus] || 0) + 1
+      }
+      if (session.deviceMode) {
+        existing.deviceCounts[session.deviceMode] = (existing.deviceCounts[session.deviceMode] || 0) + 1
+      }
+      acc[mode] = existing
+      return acc
+    }, {} as Record<string, {
+      mode: string
+      bouts: number
+      totalSeconds: number
+      fusionHeldSeconds: number
+      focusCounts: Record<string, number>
+      deviceCounts: Record<string, number>
+    }>)
+
+    const binocularSummary = {
+      totalBouts: binocularSessions.length,
+      totalSeconds: binocularSessions.reduce((sum, session) => sum + (session.duration || 0), 0),
+      modeBreakdown: Object.values(modeBreakdown)
+        .map(mode => ({
+          ...mode,
+          totalMinutes: Math.round((mode.totalSeconds / 60) * 10) / 10,
+          fusionHeldMinutes: Math.round((mode.fusionHeldSeconds / 60) * 10) / 10
+        }))
+        .sort((a, b) => b.totalSeconds - a.totalSeconds)
+    }
+
     // Calculate weekly trend
     const weekAgo = new Date()
     weekAgo.setDate(weekAgo.getDate() - 7)
@@ -57,6 +108,7 @@ export async function GET(request: Request) {
       success: true,
       progress,
       recentSessions,
+      binocularSummary,
       weeklyStats: {
         sessionsThisWeek: weekSessions.length,
         avgAccuracyThisWeek: weekSessions.length > 0

--- a/app/api/vision/sessions/route.ts
+++ b/app/api/vision/sessions/route.ts
@@ -126,7 +126,15 @@ export async function POST(request: Request) {
       accuracy,
       chartSize,
       duration,
-      success
+      success,
+      deviceMode,
+      trainingFocus,
+      binocularMode,
+      sessionSource,
+      binocularOutcome,
+      binocularFusionHeldSeconds,
+      binocularAttempts,
+      binocularCorrect
     } = body
 
     // Validate required fields
@@ -146,7 +154,15 @@ export async function POST(request: Request) {
         accuracy,
         chartSize: chartSize || '20/20',
         duration: duration || 0,
-        success: success || false
+        success: success || false,
+        deviceMode: deviceMode || null,
+        trainingFocus: trainingFocus || visionType,
+        binocularMode: binocularMode && binocularMode !== 'off' ? binocularMode : null,
+        sessionSource: sessionSource || null,
+        binocularOutcome: binocularOutcome || null,
+        binocularFusionHeldSeconds: binocularFusionHeldSeconds ?? null,
+        binocularAttempts: binocularAttempts ?? null,
+        binocularCorrect: binocularCorrect ?? null
       }
     })
 

--- a/prisma/migrations/20260703163500_add_binocular_vision_metrics/README.md
+++ b/prisma/migrations/20260703163500_add_binocular_vision_metrics/README.md
@@ -1,0 +1,18 @@
+# Add binocular vision training metrics
+
+Mongo deployment note for Prisma schema changes in this PR.
+
+This change adds optional fields only:
+
+- `VisionSession.deviceMode`
+- `VisionSession.trainingFocus`
+- `VisionSession.binocularMode`
+- `VisionSession.sessionSource`
+- `VisionSession.binocularOutcome`
+- `VisionSession.binocularFusionHeldSeconds`
+- `VisionSession.binocularAttempts`
+- `VisionSession.binocularCorrect`
+- `VisionDailySession.binocularResults`
+
+No existing records require backfill. Deploy with the normal Prisma Mongo flow
+for this project, then run `prisma generate`.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -995,6 +995,17 @@ model VisionSession {
   chartSize    String   // Which line was being tested (e.g., "20/20", "20/40")
   duration     Int      // Session duration in seconds
   success      Boolean  // Did they pass this level?
+
+  // Optional binocular training metadata
+  deviceMode                   String? // "phone" | "desktop"
+  trainingFocus                String? // "near" | "far"
+  binocularMode                String? // "duplicate" | "redgreen" | "grid-square" | "grid-slanted" | "alternating"
+  sessionSource                String? // "focus" | "daily"
+  binocularOutcome             String? // "completed" | "exited" | "reset"
+  binocularFusionHeldSeconds   Int?
+  binocularAttempts            Int?
+  binocularCorrect             Int?
+
   createdAt    DateTime @default(now())
   user         User     @relation(fields: [userId], references: [id])
 
@@ -1146,6 +1157,7 @@ model VisionDailySession {
 
   // Performance data
   accuracy          Float?   // Overall accuracy if tracked
+  binocularResults  Json?    // Optional binocular bout summaries captured during the daily flow
   notes             String?  // User notes
   coachFeedback     String?  // Any specific feedback
 

--- a/src/components/Vision/Training/DailyPractice.tsx
+++ b/src/components/Vision/Training/DailyPractice.tsx
@@ -13,7 +13,8 @@ import {
   Coffee,
   BookOpen
 } from 'lucide-react'
-import TrainingSession from './TrainingSession'
+import TrainingSession, { type BinocularTrainingResult } from './TrainingSession'
+import type { BinocularMode } from './BinocularChart'
 
 interface DailySession {
   day: number
@@ -72,6 +73,15 @@ interface ProgramInfo {
   phases: { name: string; weeks: string; focus: string }[]
 }
 
+const dailyBinocularModes: Array<{ value: BinocularMode; label: string }> = [
+  { value: 'off', label: 'Standard' },
+  { value: 'duplicate', label: 'Duplicate' },
+  { value: 'redgreen', label: 'Red/Green' },
+  { value: 'grid-square', label: 'Grid Square' },
+  { value: 'grid-slanted', label: 'Grid Slanted' },
+  { value: 'alternating', label: 'Alternating' }
+]
+
 export default function DailyPractice() {
   const [loading, setLoading] = useState(true)
   const [enrolled, setEnrolled] = useState(false)
@@ -87,6 +97,9 @@ export default function DailyPractice() {
   const [nearSnellenResult, setNearSnellenResult] = useState('')
   const [farSnellenResult, setFarSnellenResult] = useState('')
   const [enrolling, setEnrolling] = useState(false)
+  const [dailyBinocularMode, setDailyBinocularMode] = useState<BinocularMode>('off')
+  const [dailyDeviceMode, setDailyDeviceMode] = useState<'phone' | 'desktop'>('phone')
+  const [dailyBinocularResults, setDailyBinocularResults] = useState<BinocularTrainingResult[]>([])
 
   useEffect(() => {
     loadProgram()
@@ -166,6 +179,7 @@ export default function DailyPractice() {
             exercisesCompleted: completedExercises,
             nearSnellenResult: nearSnellenResult || null,
             farSnellenResult: farSnellenResult || null,
+            binocularResults: dailyBinocularResults.length > 0 ? dailyBinocularResults : null,
             notes: sessionNotes || null
           }
         })
@@ -173,6 +187,7 @@ export default function DailyPractice() {
 
       const data = await response.json()
       if (data.success) {
+        setDailyBinocularResults([])
         loadProgram() // Reload to show completion
       }
     } catch (error) {
@@ -385,6 +400,36 @@ export default function DailyPractice() {
     )
   }
 
+  const renderDailyTrainerControls = () => (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div>
+        <label className="text-gray-400 text-xs block mb-1">Trainer Mode</label>
+        <select
+          value={dailyBinocularMode}
+          onChange={(e) => setDailyBinocularMode(e.target.value as BinocularMode)}
+          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white text-sm"
+        >
+          {dailyBinocularModes.map((mode) => (
+            <option key={mode.value} value={mode.value}>
+              {mode.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="text-gray-400 text-xs block mb-1">Device</label>
+        <select
+          value={dailyDeviceMode}
+          onChange={(e) => setDailyDeviceMode(e.target.value as 'phone' | 'desktop')}
+          className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white text-sm"
+        >
+          <option value="phone">Phone</option>
+          <option value="desktop">Desktop</option>
+        </select>
+      </div>
+    </div>
+  )
+
   // Show Snellen trainer
   if (showSnellenTrainer) {
     return (
@@ -400,6 +445,12 @@ export default function DailyPractice() {
           visionType="near"
           exerciseType="letters"
           initialLevel={1}
+          deviceMode={dailyDeviceMode}
+          binocularMode={dailyBinocularMode}
+          sessionSource="daily"
+          onBinocularResult={(result) => {
+            setDailyBinocularResults(prev => [...prev, result])
+          }}
         />
       </div>
     )
@@ -473,6 +524,7 @@ export default function DailyPractice() {
                     Open Trainer
                   </button>
                 </div>
+                {renderDailyTrainerControls()}
 
                 <div className="bg-gradient-to-br from-gray-800/80 to-gray-900/80 backdrop-blur-sm rounded-xl p-4 border border-primary-400/20">
                   <div className="flex items-center gap-3 mb-3">
@@ -576,6 +628,10 @@ export default function DailyPractice() {
                           <option value="20/15">20/15</option>
                         </select>
                       </div>
+                    </div>
+
+                    <div className="mb-4">
+                      {renderDailyTrainerControls()}
                     </div>
 
                     <div className="flex gap-3">

--- a/src/components/Vision/Training/ProgressDashboard.tsx
+++ b/src/components/Vision/Training/ProgressDashboard.tsx
@@ -21,12 +21,53 @@ interface VisionSession {
   chartSize: string
   duration: number
   success: boolean
+  deviceMode?: string | null
+  trainingFocus?: string | null
+  binocularMode?: string | null
+  sessionSource?: string | null
+  binocularOutcome?: string | null
+  binocularFusionHeldSeconds?: number | null
   createdAt: string
+}
+
+interface BinocularModeSummary {
+  mode: string
+  bouts: number
+  totalSeconds: number
+  totalMinutes: number
+  fusionHeldSeconds: number
+  fusionHeldMinutes: number
+  focusCounts: Record<string, number>
+  deviceCounts: Record<string, number>
+}
+
+interface BinocularSummary {
+  totalBouts: number
+  totalSeconds: number
+  modeBreakdown: BinocularModeSummary[]
+}
+
+const BINOCULAR_MODE_LABELS: Record<string, string> = {
+  duplicate: 'Duplicate',
+  redgreen: 'Red/Green',
+  'grid-square': 'Grid Square',
+  'grid-slanted': 'Grid Slanted',
+  alternating: 'Alternating'
+}
+
+function formatMode(mode?: string | null) {
+  if (!mode) return ''
+  return BINOCULAR_MODE_LABELS[mode] || mode
 }
 
 export default function ProgressDashboard() {
   const [progress, setProgress] = useState<VisionProgress[]>([])
   const [recentSessions, setRecentSessions] = useState<VisionSession[]>([])
+  const [binocularSummary, setBinocularSummary] = useState<BinocularSummary>({
+    totalBouts: 0,
+    totalSeconds: 0,
+    modeBreakdown: []
+  })
   const [weeklyStats, setWeeklyStats] = useState({
     sessionsThisWeek: 0,
     avgAccuracyThisWeek: 0,
@@ -46,6 +87,11 @@ export default function ProgressDashboard() {
       if (data.success) {
         setProgress(data.progress || [])
         setRecentSessions(data.recentSessions || [])
+        setBinocularSummary(data.binocularSummary || {
+          totalBouts: 0,
+          totalSeconds: 0,
+          modeBreakdown: []
+        })
         setWeeklyStats(data.weeklyStats || {
           sessionsThisWeek: 0,
           avgAccuracyThisWeek: 0,
@@ -61,6 +107,7 @@ export default function ProgressDashboard() {
 
   const nearProgress = progress.find(p => p.visionType === 'near')
   const farProgress = progress.find(p => p.visionType === 'far')
+  const totalBinocularMinutes = Math.round((binocularSummary.totalSeconds / 60) * 10) / 10
 
   if (loading) {
     return (
@@ -96,6 +143,59 @@ export default function ProgressDashboard() {
             </p>
           </div>
         </div>
+      </div>
+
+      {/* Binocular training usage */}
+      <div className="bg-gray-900/40 border border-orange-400/30 rounded-lg p-6 shadow-inner">
+        <h4 className="text-lg font-bold text-white mb-4 flex items-center gap-2">
+          <Eye className="w-5 h-5 text-orange-400" />
+          Binocular Training Usage
+        </h4>
+        {binocularSummary.totalBouts > 0 ? (
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div className="bg-gray-800/50 rounded-lg p-4">
+                <p className="text-gray-400 text-sm mb-1">Bouts Logged</p>
+                <p className="text-2xl font-bold text-white">{binocularSummary.totalBouts}</p>
+              </div>
+              <div className="bg-gray-800/50 rounded-lg p-4">
+                <p className="text-gray-400 text-sm mb-1">Training Minutes</p>
+                <p className="text-2xl font-bold text-orange-300">{totalBinocularMinutes}</p>
+              </div>
+              <div className="bg-gray-800/50 rounded-lg p-4">
+                <p className="text-gray-400 text-sm mb-1">Modes Used</p>
+                <p className="text-2xl font-bold text-primary-300">{binocularSummary.modeBreakdown.length}</p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              {binocularSummary.modeBreakdown.map((mode) => (
+                <div key={mode.mode} className="bg-gray-800/50 rounded-lg p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-white font-semibold">{formatMode(mode.mode)}</p>
+                      <p className="text-xs text-gray-400">
+                        {mode.bouts} bout{mode.bouts === 1 ? '' : 's'} - {mode.totalMinutes} min
+                      </p>
+                    </div>
+                    <div className="text-right text-xs text-gray-400">
+                      <p>Fusion held: {mode.fusionHeldMinutes} min</p>
+                      <p>
+                        {Object.entries(mode.deviceCounts)
+                          .map(([device, count]) => `${device}: ${count}`)
+                          .join(' | ') || 'No device data'}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <p className="text-gray-400 text-sm">
+            No binocular training recorded yet. Complete or exit a binocular focus-training bout to see mode usage here.
+          </p>
+        )}
       </div>
 
       {/* Vision type progress */}
@@ -204,6 +304,11 @@ export default function ProgressDashboard() {
                     </span>
                     {session.success && (
                       <Award className="w-4 h-4 text-yellow-400" />
+                    )}
+                    {session.binocularMode && (
+                      <span className="px-2 py-0.5 rounded text-xs font-semibold bg-orange-500/20 text-orange-300">
+                        {formatMode(session.binocularMode)}
+                      </span>
                     )}
                   </div>
                   <p className="text-xs text-gray-400">

--- a/src/components/Vision/Training/TrainingSession.tsx
+++ b/src/components/Vision/Training/TrainingSession.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import SnellenChart from './SnellenChart'
 import BinocularChart from './BinocularChart'
 import type { BinocularMode } from './BinocularChart'
@@ -14,8 +14,25 @@ interface TrainingSessionProps {
   deviceMode?: 'phone' | 'desktop'
   binocularMode?: BinocularMode
   untimed?: boolean
+  sessionSource?: 'focus' | 'daily'
+  onBinocularResult?: (result: BinocularTrainingResult) => void | Promise<void>
   onActiveChange?: (isActive: boolean) => void
   onExit?: () => void
+}
+
+type BinocularOutcome = 'completed' | 'exited' | 'reset'
+
+export interface BinocularTrainingResult {
+  binocularMode: BinocularMode
+  deviceMode: 'phone' | 'desktop'
+  trainingFocus: 'near' | 'far'
+  durationSeconds: number
+  outcome: BinocularOutcome
+  fusionHeldSeconds: number
+  attempts: number
+  correct: number
+  accuracy: number
+  source: 'focus' | 'daily'
 }
 
 // Reader glasses progression for nearsightedness training
@@ -49,6 +66,8 @@ export default function TrainingSession({
   deviceMode = 'phone',
   binocularMode = 'off',
   untimed = false,
+  sessionSource = 'focus',
+  onBinocularResult,
   onActiveChange,
   onExit
 }: TrainingSessionProps) {
@@ -69,10 +88,15 @@ export default function TrainingSession({
   const [distanceProgressionMode, setDistanceProgressionMode] = useState(visionType === 'near')
   const [showGlassesPrompt, setShowGlassesPrompt] = useState(false)
   const [consecutiveSuccessAtMax, setConsecutiveSuccessAtMax] = useState(0)
+  const binocularRecordedRef = useRef(false)
 
   const difficulty = DIFFICULTY_LEVELS[currentLevel - 1] || DIFFICULTY_LEVELS[0]
   const accuracy = attempts > 0 ? (correct / attempts) * 100 : 0
   const currentGlassesStage = READER_GLASSES_STAGES[readerGlassesStage] || READER_GLASSES_STAGES[0]
+
+  useEffect(() => {
+    binocularRecordedRef.current = false
+  }, [binocularMode, deviceMode, exerciseType, initialLevel, sessionSource, visionType])
 
   // Reset target distance if device mode changes
   useEffect(() => {
@@ -145,7 +169,11 @@ export default function TrainingSession({
           setTimeout(() => {
             setSessionComplete(true)
             setIsActive(false)
-            saveSession(true)
+            if (isBinocular) {
+              void recordBinocularBout('completed', true)
+            } else {
+              void saveSession(true)
+            }
           }, 1500)
         }
       } else {
@@ -209,7 +237,28 @@ export default function TrainingSession({
     }
   }
 
-  const saveSession = async (success: boolean) => {
+  const buildBinocularResult = (outcome: BinocularOutcome): BinocularTrainingResult => {
+    const durationSeconds = Math.max(sessionDuration, 1)
+    const effectiveAccuracy = attempts > 0 ? (correct / attempts) * 100 : 0
+    const fusionHeldSeconds = attempts > 0
+      ? Math.round(durationSeconds * (correct / attempts))
+      : durationSeconds
+
+    return {
+      binocularMode: binocularMode as BinocularMode,
+      deviceMode,
+      trainingFocus: visionType,
+      durationSeconds,
+      outcome,
+      fusionHeldSeconds,
+      attempts,
+      correct,
+      accuracy: effectiveAccuracy,
+      source: sessionSource
+    }
+  }
+
+  const saveSession = async (success: boolean, binocularResult?: BinocularTrainingResult) => {
     try {
       await fetch('/api/vision/sessions', {
         method: 'POST',
@@ -218,10 +267,20 @@ export default function TrainingSession({
           visionType,
           exerciseType,
           distanceCm: distanceProgressionMode ? targetDistanceCm : difficulty.targetDistance,
-          accuracy,
-          level: difficulty.label,
-          duration: sessionDuration,
-          success
+          accuracy: binocularResult?.accuracy ?? accuracy,
+          chartSize: difficulty.label,
+          duration: binocularResult?.durationSeconds ?? sessionDuration,
+          success,
+          ...(binocularResult ? {
+            deviceMode: binocularResult.deviceMode,
+            trainingFocus: binocularResult.trainingFocus,
+            binocularMode: binocularResult.binocularMode,
+            sessionSource: binocularResult.source,
+            binocularOutcome: binocularResult.outcome,
+            binocularFusionHeldSeconds: binocularResult.fusionHeldSeconds,
+            binocularAttempts: binocularResult.attempts,
+            binocularCorrect: binocularResult.correct
+          } : {})
         })
       })
     } catch (error) {
@@ -229,7 +288,30 @@ export default function TrainingSession({
     }
   }
 
+  const recordBinocularBout = async (outcome: BinocularOutcome, success = false) => {
+    if (!isBinocular || binocularRecordedRef.current) return
+
+    binocularRecordedRef.current = true
+    const result = buildBinocularResult(outcome)
+    try {
+      await onBinocularResult?.(result)
+    } catch (error) {
+      console.error('Failed to handle binocular result:', error)
+    }
+    await saveSession(success, result)
+  }
+
+  const handleExit = () => {
+    void recordBinocularBout('exited', false)
+    if (onExit) {
+      onExit()
+    } else {
+      setIsActive(false)
+    }
+  }
+
   const resetSession = () => {
+    void recordBinocularBout('reset', false)
     setCurrentLevel(initialLevel)
     setAttempts(0)
     setCorrect(0)
@@ -264,7 +346,7 @@ export default function TrainingSession({
             </div>
             <div className="flex items-center gap-2">
               <button
-                onClick={onExit || (() => setIsActive(false))}
+                onClick={handleExit}
                 className="px-3 py-1.5 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm font-semibold flex items-center gap-1.5 transition-all"
                 title="Exit training (ESC)"
               >

--- a/src/components/Vision/VisionTraining.tsx
+++ b/src/components/Vision/VisionTraining.tsx
@@ -451,6 +451,7 @@ export function VisionTraining() {
                           deviceMode={trainerDeviceMode}
                           binocularMode={binocularMode}
                           untimed={untimedMode}
+                          sessionSource="focus"
                           onExit={() => setIsTrainingActive(false)}
                           onActiveChange={(active) => {
                             if (!active) setIsTrainingActive(false)
@@ -475,6 +476,7 @@ export function VisionTraining() {
                       deviceMode={trainerDeviceMode}
                       binocularMode={binocularMode}
                       untimed={untimedMode}
+                      sessionSource="focus"
                       onActiveChange={(active) => {
                         if (!active) setIsTrainingActive(false)
                       }}


### PR DESCRIPTION
## Summary
- Add optional binocular metadata to vision session saves: mode, device, focus, source, outcome, duration/fusion estimates, attempts/correct.
- Record binocular bouts from Focus Training on completion, exit, or reset without changing the six binocular chart modes.
- Add daily-practice baseline trainer mode/device controls and persist daily binocular summaries on session completion.
- Add progress API aggregation and dashboard display for binocular minutes, bouts, and per-mode breakdown.

## Verification
- `npx prisma validate` with `DATABASE_URL=mongodb://localhost:27017/resetbiology`
- `npx prisma generate` with `DATABASE_URL=mongodb://localhost:27017/resetbiology`
- `npx tsc --noEmit`
- `npm run build` (passes; local Auth0 env warnings and Next multi-lockfile workspace warning are existing/local config)
- `git diff --check`
- Local smoke on `http://localhost:3101/vision-training`: opened Focus Training, selected Duplicate binocular mode, started trainer; no page exceptions. Console only showed expected unauthenticated 401 API resource errors.
- API smoke: unauthenticated `GET /api/vision/progress` and binocular `POST /api/vision/sessions` both return 401.

## Notes
- Prisma change is additive only for Mongo optional fields; no backfill required.
- This PR does not merge or depend on the Phase A PRs that are still pending on `master`.

Worklist: jonchyatt/codex-worklist#11