### PR TITLE
[worklist#10] Vision Training progress charts

### DIFF
--- a/app/api/vision/progress/route.ts
+++ b/app/api/vision/progress/route.ts
@@ -2,6 +2,40 @@ import { NextResponse } from 'next/server'
 import { auth0 } from '@/lib/auth0'
 import { prisma } from '@/lib/prisma'
 
+const PHASE_BOUNDARY_WEEKS = [2, 4, 6, 8, 10]
+
+interface SnellenTrendPoint {
+  x: number
+  week: number | null
+  day: number | null
+  date: Date
+  baseline?: boolean
+  denominator: number
+  display: string
+  label: string
+}
+
+function parseSnellenDenominator(value?: string | null) {
+  if (!value) return null
+  const match = value.match(/^20\s*\/\s*(\d+)/i)
+  if (!match) return null
+
+  const denominator = Number(match[1])
+  return Number.isFinite(denominator) ? denominator : null
+}
+
+function dailySessionX(week: number, day: number) {
+  const normalizedWeek = Math.max(1, Math.min(12, week))
+  const normalizedDay = Math.max(1, Math.min(5, day || 1))
+  return normalizedWeek - 1 + normalizedDay / 5
+}
+
+function weekFromProgramStart(startDate: Date, eventDate: Date) {
+  const dayMs = 24 * 60 * 60 * 1000
+  const elapsedDays = Math.max(0, Math.floor((eventDate.getTime() - startDate.getTime()) / dayMs))
+  return Math.max(1, Math.min(12, Math.floor(elapsedDays / 7) + 1))
+}
+
 // GET: Load user's vision training progress
 export async function GET(request: Request) {
   try {
@@ -45,6 +79,132 @@ export async function GET(request: Request) {
       take: 20
     })
 
+    const trendSessions = await prisma.visionSession.findMany({
+      where: { userId: user.id },
+      orderBy: { createdAt: 'asc' },
+      take: 200
+    })
+
+    const enrollment = await prisma.visionProgramEnrollment.findUnique({
+      where: { userId: user.id },
+      include: {
+        dailySessions: {
+          orderBy: [
+            { week: 'asc' },
+            { day: 'asc' },
+            { completedAt: 'asc' }
+          ]
+        }
+      }
+    })
+
+    const dailySessions = enrollment?.dailySessions || []
+    const snellenNear: SnellenTrendPoint[] = []
+    const snellenFar: SnellenTrendPoint[] = []
+
+    const addSnellenPoint = (
+      series: SnellenTrendPoint[],
+      value: string | null | undefined,
+      point: { x: number; week: number | null; day: number | null; date: Date; baseline?: boolean }
+    ) => {
+      const denominator = parseSnellenDenominator(value)
+      if (!denominator || !value) return
+
+      series.push({
+        ...point,
+        denominator,
+        display: value,
+        label: point.baseline ? 'Baseline' : `W${point.week}D${point.day}`
+      })
+    }
+
+    if (enrollment) {
+      addSnellenPoint(snellenNear, enrollment.initialNearSnellen, {
+        x: 0,
+        week: null,
+        day: null,
+        date: enrollment.startDate,
+        baseline: true
+      })
+      addSnellenPoint(snellenFar, enrollment.initialFarSnellen, {
+        x: 0,
+        week: null,
+        day: null,
+        date: enrollment.startDate,
+        baseline: true
+      })
+    }
+
+    dailySessions.forEach((dailySession) => {
+      const point = {
+        x: dailySessionX(dailySession.week, dailySession.day),
+        week: dailySession.week,
+        day: dailySession.day,
+        date: dailySession.completedAt,
+        baseline: false
+      }
+
+      addSnellenPoint(snellenNear, dailySession.nearSnellenResult, point)
+      addSnellenPoint(snellenFar, dailySession.farSnellenResult, point)
+    })
+
+    const weeklyMinutes = Array.from({ length: 12 }, (_, index) => ({
+      week: index + 1,
+      baselineMinutes: 0,
+      exerciseMinutes: 0,
+      totalMinutes: 0,
+      sessions: 0
+    }))
+
+    dailySessions.forEach((dailySession) => {
+      if (dailySession.week < 1 || dailySession.week > 12) return
+      const weekly = weeklyMinutes[dailySession.week - 1]
+      weekly.baselineMinutes += dailySession.baselineMinutes || 0
+      weekly.exerciseMinutes += dailySession.exerciseMinutes || 0
+      weekly.totalMinutes += dailySession.totalMinutes || 0
+      weekly.sessions += 1
+    })
+
+    const accuracyTrend = trendSessions.map((visionSession, index) => {
+      const eventDate = new Date(visionSession.createdAt)
+      const week = enrollment ? weekFromProgramStart(enrollment.startDate, eventDate) : null
+
+      return {
+        x: week || Math.min(12, index + 1),
+        week,
+        date: eventDate,
+        label: week ? `Week ${week}` : `Session ${index + 1}`,
+        accuracy: visionSession.accuracy,
+        visionType: visionSession.visionType,
+        exerciseType: visionSession.exerciseType
+      }
+    })
+
+    dailySessions.forEach((dailySession) => {
+      if (dailySession.accuracy === null || dailySession.accuracy === undefined) return
+      accuracyTrend.push({
+        x: dailySessionX(dailySession.week, dailySession.day),
+        week: dailySession.week,
+        date: dailySession.completedAt,
+        label: `W${dailySession.week}D${dailySession.day}`,
+        accuracy: dailySession.accuracy,
+        visionType: 'daily',
+        exerciseType: 'program'
+      })
+    })
+
+    accuracyTrend.sort((a, b) => a.date.getTime() - b.date.getTime())
+
+    const trendData = {
+      phaseBoundaries: PHASE_BOUNDARY_WEEKS,
+      snellen: {
+        near: snellenNear,
+        far: snellenFar
+      },
+      accuracy: accuracyTrend,
+      weeklyMinutes
+    }
+
     // Calculate weekly trend
     const weekAgo = new Date()
     weekAgo.setDate(weekAgo.getDate() - 7)
@@ -57,6 +217,7 @@ export async function GET(request: Request) {
       success: true,
       progress,
       recentSessions,
+      trendData,
       weeklyStats: {
         sessionsThisWeek: weekSessions.length,
         avgAccuracyThisWeek: weekSessions.length > 0

--- a/src/components/Vision/Training/ProgressDashboard.tsx
+++ b/src/components/Vision/Training/ProgressDashboard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { TrendingUp, Eye, Calendar, Award } from 'lucide-react'
+import { useEffect, useState, type ReactNode } from 'react'
+import { TrendingUp, Eye, Calendar, Award, Activity, BarChart3 } from 'lucide-react'
 
 interface VisionProgress {
   id: string
@@ -24,9 +24,380 @@ interface VisionSession {
   createdAt: string
 }
 
+interface SnellenTrendPoint {
+  x: number
+  week: number | null
+  day: number | null
+  date: string
+  denominator: number
+  display: string
+  label: string
+  baseline?: boolean
+}
+
+interface AccuracyTrendPoint {
+  x: number
+  week: number | null
+  date: string
+  label: string
+  accuracy: number
+  visionType: string
+  exerciseType: string
+}
+
+interface WeeklyMinutesTrend {
+  week: number
+  baselineMinutes: number
+  exerciseMinutes: number
+  totalMinutes: number
+  sessions: number
+}
+
+interface TrendData {
+  phaseBoundaries: number[]
+  snellen: {
+    near: SnellenTrendPoint[]
+    far: SnellenTrendPoint[]
+  }
+  accuracy: AccuracyTrendPoint[]
+  weeklyMinutes: WeeklyMinutesTrend[]
+}
+
+interface ChartPoint {
+  x: number
+  value: number
+  label: string
+  display: string
+  baseline?: boolean
+}
+
+interface ChartSeries {
+  label: string
+  color: string
+  points: ChartPoint[]
+}
+
+const DEFAULT_TREND_DATA: TrendData = {
+  phaseBoundaries: [2, 4, 6, 8, 10],
+  snellen: {
+    near: [],
+    far: []
+  },
+  accuracy: [],
+  weeklyMinutes: []
+}
+
+const CHART = {
+  width: 720,
+  height: 260,
+  top: 22,
+  right: 20,
+  bottom: 36,
+  left: 52
+}
+
+function getYRange(values: number[], fallbackMin: number, fallbackMax: number) {
+  if (values.length === 0) return { min: fallbackMin, max: fallbackMax }
+
+  const minValue = Math.min(...values, fallbackMin)
+  const maxValue = Math.max(...values, fallbackMax)
+  if (minValue === maxValue) {
+    return {
+      min: Math.max(0, minValue - 1),
+      max: maxValue + 1
+    }
+  }
+
+  return {
+    min: minValue,
+    max: maxValue
+  }
+}
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+function ChartFrame({
+  title,
+  icon,
+  children,
+  legend
+}: {
+  title: string
+  icon: ReactNode
+  children: ReactNode
+  legend?: ReactNode
+}) {
+  return (
+    <div className="bg-gray-900/40 border border-primary-400/30 rounded-lg p-5 shadow-inner">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <h4 className="text-lg font-bold text-white flex items-center gap-2">
+          {icon}
+          {title}
+        </h4>
+        {legend}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function EmptyChart({ message }: { message: string }) {
+  return (
+    <div className="min-h-[220px] rounded-lg border border-dashed border-gray-700 bg-gray-950/30 flex items-center justify-center px-6 text-center">
+      <p className="text-sm text-gray-400">{message}</p>
+    </div>
+  )
+}
+
+function LineTrendChart({
+  title,
+  icon,
+  series,
+  phaseBoundaries,
+  emptyMessage,
+  yFormatter,
+  fallbackMin,
+  fallbackMax,
+  lowerIsBetter = false
+}: {
+  title: string
+  icon: ReactNode
+  series: ChartSeries[]
+  phaseBoundaries: number[]
+  emptyMessage: string
+  yFormatter: (value: number) => string
+  fallbackMin: number
+  fallbackMax: number
+  lowerIsBetter?: boolean
+}) {
+  const allPoints = series.flatMap(item => item.points)
+  const values = allPoints.map(point => point.value)
+  const hasData = allPoints.length > 0
+  const yRange = getYRange(values, fallbackMin, fallbackMax)
+  const innerWidth = CHART.width - CHART.left - CHART.right
+  const innerHeight = CHART.height - CHART.top - CHART.bottom
+  const toX = (x: number) => CHART.left + (Math.max(0, Math.min(12, x)) / 12) * innerWidth
+  const toY = (value: number) => {
+    const ratio = (value - yRange.min) / (yRange.max - yRange.min || 1)
+    return lowerIsBetter
+      ? CHART.top + ratio * innerHeight
+      : CHART.top + (1 - ratio) * innerHeight
+  }
+  const ticks = [yRange.min, (yRange.min + yRange.max) / 2, yRange.max]
+
+  return (
+    <ChartFrame
+      title={title}
+      icon={icon}
+      legend={
+        <div className="flex flex-wrap gap-3 text-xs">
+          {series.map(item => (
+            <span key={item.label} className="flex items-center gap-1 text-gray-300">
+              <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: item.color }} />
+              {item.label}
+            </span>
+          ))}
+        </div>
+      }
+    >
+      {!hasData ? (
+        <EmptyChart message={emptyMessage} />
+      ) : (
+        <svg viewBox={`0 0 ${CHART.width} ${CHART.height}`} className="w-full h-auto" role="img" aria-label={title}>
+          <rect x="0" y="0" width={CHART.width} height={CHART.height} rx="8" fill="rgba(17,24,39,0.35)" />
+          {ticks.map(tick => (
+            <g key={tick}>
+              <line
+                x1={CHART.left}
+                x2={CHART.width - CHART.right}
+                y1={toY(tick)}
+                y2={toY(tick)}
+                stroke="rgba(75,85,99,0.45)"
+                strokeDasharray="4 4"
+              />
+              <text x={CHART.left - 10} y={toY(tick) + 4} textAnchor="end" className="fill-gray-400 text-[11px]">
+                {yFormatter(tick)}
+              </text>
+            </g>
+          ))}
+          {phaseBoundaries.map(week => (
+            <g key={week}>
+              <line
+                x1={toX(week)}
+                x2={toX(week)}
+                y1={CHART.top}
+                y2={CHART.height - CHART.bottom}
+                stroke="rgba(251,191,36,0.55)"
+                strokeDasharray="3 5"
+              />
+              <text x={toX(week) + 4} y={CHART.top + 12} className="fill-yellow-300 text-[10px]">
+                W{week}
+              </text>
+            </g>
+          ))}
+          <line x1={CHART.left} x2={CHART.width - CHART.right} y1={CHART.height - CHART.bottom} y2={CHART.height - CHART.bottom} stroke="rgba(156,163,175,0.45)" />
+          <text x={CHART.left} y={CHART.height - 10} className="fill-gray-400 text-[11px]">Baseline</text>
+          <text x={CHART.width - CHART.right} y={CHART.height - 10} textAnchor="end" className="fill-gray-400 text-[11px]">Week 12</text>
+
+          {series.map(item => {
+            const sortedPoints = [...item.points].sort((a, b) => a.x - b.x)
+            const path = sortedPoints
+              .map((point, index) => `${index === 0 ? 'M' : 'L'} ${toX(point.x)} ${toY(point.value)}`)
+              .join(' ')
+
+            return (
+              <g key={item.label}>
+                {sortedPoints.length > 1 && (
+                  <path d={path} fill="none" stroke={item.color} strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+                )}
+                {sortedPoints.map((point, index) => (
+                  <g key={`${item.label}-${point.label}-${index}`}>
+                    <circle
+                      cx={toX(point.x)}
+                      cy={toY(point.value)}
+                      r={point.baseline ? 6 : 4}
+                      fill={point.baseline ? '#111827' : item.color}
+                      stroke={item.color}
+                      strokeWidth={point.baseline ? 3 : 2}
+                    >
+                      <title>{`${item.label} ${point.label}: ${point.display}`}</title>
+                    </circle>
+                    {point.baseline && (
+                      <text x={toX(point.x) + 8} y={toY(point.value) - 8} className="fill-gray-300 text-[10px]">
+                        Baseline
+                      </text>
+                    )}
+                  </g>
+                ))}
+              </g>
+            )
+          })}
+        </svg>
+      )}
+    </ChartFrame>
+  )
+}
+
+function WeeklyMinutesChart({
+  data,
+  phaseBoundaries
+}: {
+  data: WeeklyMinutesTrend[]
+  phaseBoundaries: number[]
+}) {
+  const hasData = data.some(item => item.totalMinutes > 0 || item.exerciseMinutes > 0)
+  const maxMinutes = Math.max(20, ...data.map(item => item.totalMinutes))
+  const innerWidth = CHART.width - CHART.left - CHART.right
+  const innerHeight = CHART.height - CHART.top - CHART.bottom
+  const toX = (week: number) => CHART.left + ((week - 0.5) / 12) * innerWidth
+  const boundaryX = (week: number) => CHART.left + (week / 12) * innerWidth
+  const toY = (value: number) => CHART.top + (1 - value / maxMinutes) * innerHeight
+  const barWidth = innerWidth / 12 * 0.55
+  const ticks = [0, maxMinutes / 2, maxMinutes]
+
+  return (
+    <ChartFrame
+      title="Weekly Practice Minutes"
+      icon={<BarChart3 className="w-5 h-5 text-secondary-400" />}
+      legend={
+        <div className="flex flex-wrap gap-3 text-xs">
+          <span className="flex items-center gap-1 text-gray-300">
+            <span className="w-2.5 h-2.5 rounded-full bg-secondary-400" />
+            Exercise
+          </span>
+          <span className="flex items-center gap-1 text-gray-300">
+            <span className="w-2.5 h-2.5 rounded-full bg-primary-400" />
+            Baseline
+          </span>
+        </div>
+      }
+    >
+      {!hasData ? (
+        <EmptyChart message="Weekly minutes will appear after daily program sessions are completed." />
+      ) : (
+        <svg viewBox={`0 0 ${CHART.width} ${CHART.height}`} className="w-full h-auto" role="img" aria-label="Weekly practice minutes">
+          <rect x="0" y="0" width={CHART.width} height={CHART.height} rx="8" fill="rgba(17,24,39,0.35)" />
+          {ticks.map(tick => (
+            <g key={tick}>
+              <line
+                x1={CHART.left}
+                x2={CHART.width - CHART.right}
+                y1={toY(tick)}
+                y2={toY(tick)}
+                stroke="rgba(75,85,99,0.45)"
+                strokeDasharray="4 4"
+              />
+              <text x={CHART.left - 10} y={toY(tick) + 4} textAnchor="end" className="fill-gray-400 text-[11px]">
+                {Math.round(tick)}
+              </text>
+            </g>
+          ))}
+          {phaseBoundaries.map(week => (
+            <g key={week}>
+              <line
+                x1={boundaryX(week)}
+                x2={boundaryX(week)}
+                y1={CHART.top}
+                y2={CHART.height - CHART.bottom}
+                stroke="rgba(251,191,36,0.55)"
+                strokeDasharray="3 5"
+              />
+              <text x={boundaryX(week) + 4} y={CHART.top + 12} className="fill-yellow-300 text-[10px]">
+                W{week}
+              </text>
+            </g>
+          ))}
+          <line x1={CHART.left} x2={CHART.width - CHART.right} y1={CHART.height - CHART.bottom} y2={CHART.height - CHART.bottom} stroke="rgba(156,163,175,0.45)" />
+          {data.map(item => {
+            const exerciseTop = toY(item.exerciseMinutes)
+            const baselineTop = toY(item.exerciseMinutes + item.baselineMinutes)
+            const baseY = CHART.height - CHART.bottom
+            const x = toX(item.week) - barWidth / 2
+
+            return (
+              <g key={item.week}>
+                {item.exerciseMinutes > 0 && (
+                  <rect
+                    x={x}
+                    y={exerciseTop}
+                    width={barWidth}
+                    height={baseY - exerciseTop}
+                    rx="4"
+                    fill="#34d399"
+                  >
+                    <title>{`Week ${item.week}: ${item.exerciseMinutes} exercise minutes`}</title>
+                  </rect>
+                )}
+                {item.baselineMinutes > 0 && (
+                  <rect
+                    x={x}
+                    y={baselineTop}
+                    width={barWidth}
+                    height={exerciseTop - baselineTop}
+                    rx="4"
+                    fill="#38bdf8"
+                  >
+                    <title>{`Week ${item.week}: ${item.baselineMinutes} baseline minutes`}</title>
+                  </rect>
+                )}
+                <text x={toX(item.week)} y={CHART.height - 10} textAnchor="middle" className="fill-gray-400 text-[10px]">
+                  {item.week}
+                </text>
+              </g>
+            )
+          })}
+        </svg>
+      )}
+    </ChartFrame>
+  )
+}
+
 export default function ProgressDashboard() {
   const [progress, setProgress] = useState<VisionProgress[]>([])
   const [recentSessions, setRecentSessions] = useState<VisionSession[]>([])
+  const [trendData, setTrendData] = useState<TrendData>(DEFAULT_TREND_DATA)
   const [weeklyStats, setWeeklyStats] = useState({
     sessionsThisWeek: 0,
     avgAccuracyThisWeek: 0,
@@ -46,6 +417,7 @@ export default function ProgressDashboard() {
       if (data.success) {
         setProgress(data.progress || [])
         setRecentSessions(data.recentSessions || [])
+        setTrendData(data.trendData || DEFAULT_TREND_DATA)
         setWeeklyStats(data.weeklyStats || {
           sessionsThisWeek: 0,
           avgAccuracyThisWeek: 0,
@@ -61,6 +433,68 @@ export default function ProgressDashboard() {
 
   const nearProgress = progress.find(p => p.visionType === 'near')
   const farProgress = progress.find(p => p.visionType === 'far')
+  const snellenSeries: ChartSeries[] = [
+    {
+      label: 'Near',
+      color: '#38bdf8',
+      points: trendData.snellen.near.map(point => ({
+        x: point.x,
+        value: point.denominator,
+        label: point.label,
+        display: point.display,
+        baseline: point.baseline
+      }))
+    },
+    {
+      label: 'Far',
+      color: '#a78bfa',
+      points: trendData.snellen.far.map(point => ({
+        x: point.x,
+        value: point.denominator,
+        label: point.label,
+        display: point.display,
+        baseline: point.baseline
+      }))
+    }
+  ]
+  const accuracySeries: ChartSeries[] = [
+    {
+      label: 'Near',
+      color: '#2dd4bf',
+      points: trendData.accuracy
+        .filter(point => point.visionType === 'near')
+        .map(point => ({
+          x: point.x,
+          value: point.accuracy,
+          label: `${point.label} ${formatDate(point.date)}`,
+          display: `${point.accuracy.toFixed(0)}%`
+        }))
+    },
+    {
+      label: 'Far',
+      color: '#f59e0b',
+      points: trendData.accuracy
+        .filter(point => point.visionType === 'far')
+        .map(point => ({
+          x: point.x,
+          value: point.accuracy,
+          label: `${point.label} ${formatDate(point.date)}`,
+          display: `${point.accuracy.toFixed(0)}%`
+        }))
+    },
+    {
+      label: 'Daily',
+      color: '#f472b6',
+      points: trendData.accuracy
+        .filter(point => point.visionType === 'daily')
+        .map(point => ({
+          x: point.x,
+          value: point.accuracy,
+          label: `${point.label} ${formatDate(point.date)}`,
+          display: `${point.accuracy.toFixed(0)}%`
+        }))
+    }
+  ]
 
   if (loading) {
     return (
@@ -95,6 +529,37 @@ export default function ProgressDashboard() {
               {weeklyStats.successRateThisWeek.toFixed(0)}%
             </p>
           </div>
+        </div>
+      </div>
+
+      {/* Trend charts */}
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <LineTrendChart
+          title="Snellen Acuity Trend"
+          icon={<Eye className="w-5 h-5 text-primary-400" />}
+          series={snellenSeries}
+          phaseBoundaries={trendData.phaseBoundaries}
+          emptyMessage="Snellen trends will appear after a baseline or daily Snellen result is recorded."
+          yFormatter={(value) => `20/${Math.round(value)}`}
+          fallbackMin={15}
+          fallbackMax={80}
+          lowerIsBetter
+        />
+        <LineTrendChart
+          title="Session Accuracy Trend"
+          icon={<Activity className="w-5 h-5 text-secondary-400" />}
+          series={accuracySeries}
+          phaseBoundaries={trendData.phaseBoundaries}
+          emptyMessage="Accuracy trends will appear after focus-training sessions are recorded."
+          yFormatter={(value) => `${Math.round(value)}%`}
+          fallbackMin={0}
+          fallbackMax={100}
+        />
+        <div className="xl:col-span-2">
+          <WeeklyMinutesChart
+            data={trendData.weeklyMinutes}
+            phaseBoundaries={trendData.phaseBoundaries}
+          />
         </div>
       </div>
 
@@ -207,7 +672,7 @@ export default function ProgressDashboard() {
                     )}
                   </div>
                   <p className="text-xs text-gray-400">
-                    {new Date(session.createdAt).toLocaleString()} • {
+                    {new Date(session.createdAt).toLocaleString()} - {
                       session.visionType === 'near'
                         ? `${session.distanceCm} cm`
                         : `${(session.distanceCm / 100).toFixed(1)} m`
@@ -228,7 +693,7 @@ export default function ProgressDashboard() {
             ))}
           </div>
         ) : (
-          <p className="text-gray-400 text-sm">No training sessions yet. Start training to see your progress!</p>
+          <p className="text-gray-400 text-sm">No training sessions yet. Start training to see your progress.</p>
         )}
       </div>
     </div>

--- a/src/components/Vision/VisionTraining.tsx
+++ b/src/components/Vision/VisionTraining.tsx
@@ -8,6 +8,7 @@ import {
   BookOpen,
   Flame,
   Award,
+  TrendingUp,
   Smartphone,
   Monitor,
   RotateCcw
@@ -17,8 +18,9 @@ import CurriculumOverview from './Training/CurriculumOverview'
 import DailyPractice from './Training/DailyPractice'
 import QuickPractice from './Training/QuickPractice'
 import TrainingSession from './Training/TrainingSession'
+import ProgressDashboard from './Training/ProgressDashboard'
 
-type TabMode = 'today' | 'trainer' | 'exercises'
+type TabMode = 'today' | 'trainer' | 'progress' | 'exercises'
 
 interface EnrollmentData {
   currentWeek: number
@@ -165,6 +167,7 @@ export function VisionTraining() {
       icon: Play
     },
     { id: 'trainer' as TabMode, label: 'Focus Training', icon: Eye },
+    ...(isEnrolled ? [{ id: 'progress' as TabMode, label: 'Progress', icon: TrendingUp }] : []),
     { id: 'exercises' as TabMode, label: 'Vision Library', icon: BookOpen },
   ]
 
@@ -480,8 +483,13 @@ export function VisionTraining() {
                       }}
                     />
                   </div>
-                ) : null}
+            ) : null}
               </div>
+            )}
+
+            {/* PROGRESS TAB */}
+            {activeTab === 'progress' && isEnrolled && (
+              <ProgressDashboard />
             )}
 
             {/* VISION LIBRARY TAB (renamed from Quick Exercises) */}


### PR DESCRIPTION
## Summary
- Add backward-compatible `trendData` to `/api/vision/progress` for Snellen, accuracy, weekly minutes, and phase boundary series.
- Add responsive inline-SVG charts to `ProgressDashboard`: Snellen near/far trend with baseline anchors, session accuracy trend, and weekly practice minutes with phase markers.
- Expose the progress surface from `/vision-training` via a Progress tab for enrolled users.

## Charting approach
No charting library is currently present in `package.json`; the repo already uses inline SVG for lightweight visualizations, so this PR uses responsive SVG charts without adding a dependency.

## Verification
- `npx tsc --noEmit`
- `npm run build` (passes; local Auth0 env warnings and Next multi-lockfile workspace warning are existing/local config)
- `git diff --check`
- Local mocked enrolled-user smoke on `http://localhost:3102/vision-training`: desktop and mobile viewports mounted all three charts, with no page exceptions and no horizontal overflow.
- API smoke: unauthenticated `GET /api/vision/progress` and `GET /api/vision/sessions?limit=5` both return 401.

Worklist: jonchyatt/codex-worklist#10