### PR TITLE
Add vision warmup and night mode

### DIFF
--- a/app/api/vision/program/route.ts
+++ b/app/api/vision/program/route.ts
@@ -213,6 +213,7 @@ export async function POST(req: NextRequest) {
           sessionTitle: sessionData.title,
           baselineMinutes: sessionData.baselineMinutes,
           exerciseMinutes: sessionData.exerciseMinutes,
+          breathWarmupMinutes: 0,
           totalMinutes: sessionData.baselineMinutes + sessionData.exerciseMinutes,
           exercisesCompleted: sessionData.exerciseIds,
           localDate: localDate || new Date().toISOString().split('T')[0],
@@ -257,7 +258,10 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: 'Not enrolled in program' }, { status: 400 })
       }
 
-      const { week, day, baselineMinutes, exerciseMinutes, exercisesCompleted, nearSnellenResult, farSnellenResult, notes } = data
+      const { week, day, baselineMinutes, exerciseMinutes, breathWarmupMinutes, exercisesCompleted, nearSnellenResult, farSnellenResult, notes } = data
+      const completedBaselineMinutes = baselineMinutes || 0
+      const completedExerciseMinutes = exerciseMinutes || 0
+      const completedBreathWarmupMinutes = Math.max(0, Math.min(3, Number(breathWarmupMinutes) || 0))
 
       // Check if session already completed today
       const todayLocalDate = new Date().toISOString().split('T')[0]
@@ -286,9 +290,10 @@ export async function POST(req: NextRequest) {
           week,
           day,
           sessionTitle: sessionData?.title || `Week ${week} Day ${day}`,
-          baselineMinutes: baselineMinutes || 0,
-          exerciseMinutes: exerciseMinutes || 0,
-          totalMinutes: (baselineMinutes || 0) + (exerciseMinutes || 0),
+          baselineMinutes: completedBaselineMinutes,
+          exerciseMinutes: completedExerciseMinutes,
+          breathWarmupMinutes: completedBreathWarmupMinutes,
+          totalMinutes: completedBaselineMinutes + completedExerciseMinutes + completedBreathWarmupMinutes,
           exercisesCompleted: exercisesCompleted || [],
           nearSnellenResult,
           farSnellenResult,
@@ -330,7 +335,7 @@ export async function POST(req: NextRequest) {
         where: { id: enrollment.id },
         data: {
           sessionsCompleted: enrollment.sessionsCompleted + 1,
-          totalPracticeMinutes: enrollment.totalPracticeMinutes + (baselineMinutes || 0) + (exerciseMinutes || 0),
+          totalPracticeMinutes: enrollment.totalPracticeMinutes + completedBaselineMinutes + completedExerciseMinutes + completedBreathWarmupMinutes,
           streakDays: newStreakDays,
           longestStreak: Math.max(enrollment.longestStreak, newStreakDays),
           lastSessionDate: new Date(),

--- a/prisma/migrations/20260703172500_add_vision_breath_warmup_minutes/README.md
+++ b/prisma/migrations/20260703172500_add_vision_breath_warmup_minutes/README.md
@@ -1,0 +1,7 @@
+# Add vision breath warm-up minutes
+
+MongoDB migration note for the additive `VisionDailySession.breathWarmupMinutes` field.
+
+- Existing `vision_daily_sessions` documents do not require a backfill.
+- New daily vision sessions write `0` when the warm-up is skipped or disabled.
+- Completed warm-ups write the selected 1-3 minute value and include it in `totalMinutes`.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1141,6 +1141,7 @@ model VisionDailySession {
   // Session metrics
   baselineMinutes   Int
   exerciseMinutes   Int
+  breathWarmupMinutes Int?
   totalMinutes      Int
   exercisesCompleted String[] // Array of exercise IDs completed
 

--- a/src/components/Vision/Training/DailyPractice.tsx
+++ b/src/components/Vision/Training/DailyPractice.tsx
@@ -11,9 +11,20 @@ import {
   Eye,
   Zap,
   Coffee,
-  BookOpen
+  BookOpen,
+  Wind
 } from 'lucide-react'
+import MiniBreathExercise from '@/components/Breath/MiniBreathExercise'
 import TrainingSession from './TrainingSession'
+
+const BREATH_WARMUP_ENABLED_KEY = 'visionTraining.breathWarmupEnabled'
+const BREATH_WARMUP_MINUTES_KEY = 'visionTraining.breathWarmupMinutes'
+
+type BreathWarmupStatus = 'pending' | 'complete' | 'skipped'
+
+interface DailyPracticeProps {
+  nightMode?: boolean
+}
 
 interface DailySession {
   day: number
@@ -72,7 +83,7 @@ interface ProgramInfo {
   phases: { name: string; weeks: string; focus: string }[]
 }
 
-export default function DailyPractice() {
+export default function DailyPractice({ nightMode = false }: DailyPracticeProps) {
   const [loading, setLoading] = useState(true)
   const [enrolled, setEnrolled] = useState(false)
   const [enrollment, setEnrollment] = useState<Enrollment | null>(null)
@@ -87,9 +98,27 @@ export default function DailyPractice() {
   const [nearSnellenResult, setNearSnellenResult] = useState('')
   const [farSnellenResult, setFarSnellenResult] = useState('')
   const [enrolling, setEnrolling] = useState(false)
+  const [breathWarmupEnabled, setBreathWarmupEnabled] = useState(true)
+  const [breathWarmupMinutes, setBreathWarmupMinutes] = useState(1)
+  const [breathWarmupStatus, setBreathWarmupStatus] = useState<BreathWarmupStatus>('pending')
+  const [showBreathWarmup, setShowBreathWarmup] = useState(false)
 
   useEffect(() => {
     loadProgram()
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const storedEnabled = window.localStorage.getItem(BREATH_WARMUP_ENABLED_KEY)
+    if (storedEnabled !== null) {
+      setBreathWarmupEnabled(storedEnabled === 'true')
+    }
+
+    const storedMinutes = Number(window.localStorage.getItem(BREATH_WARMUP_MINUTES_KEY))
+    if ([1, 2, 3].includes(storedMinutes)) {
+      setBreathWarmupMinutes(storedMinutes)
+    }
   }, [])
 
   const loadProgram = async () => {
@@ -149,6 +178,43 @@ export default function DailyPractice() {
     }
   }
 
+  const updateBreathWarmupEnabled = (enabled: boolean) => {
+    setBreathWarmupEnabled(enabled)
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(BREATH_WARMUP_ENABLED_KEY, String(enabled))
+    }
+  }
+
+  const updateBreathWarmupMinutes = (minutes: number) => {
+    setBreathWarmupMinutes(minutes)
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(BREATH_WARMUP_MINUTES_KEY, String(minutes))
+    }
+  }
+
+  const startSessionWithOptionalWarmup = () => {
+    if (breathWarmupEnabled) {
+      setBreathWarmupStatus('pending')
+      setShowBreathWarmup(true)
+      return
+    }
+
+    setBreathWarmupStatus('skipped')
+    setSessionStarted(true)
+  }
+
+  const completeBreathWarmup = () => {
+    setBreathWarmupStatus('complete')
+    setShowBreathWarmup(false)
+    setSessionStarted(true)
+  }
+
+  const skipBreathWarmup = () => {
+    setBreathWarmupStatus('skipped')
+    setShowBreathWarmup(false)
+    setSessionStarted(true)
+  }
+
   const completeSession = async () => {
     if (!todaySession?.session || !enrollment) return
 
@@ -163,6 +229,7 @@ export default function DailyPractice() {
             day: todaySession.day,
             baselineMinutes: todaySession.session.baselineMinutes,
             exerciseMinutes: todaySession.session.exerciseMinutes,
+            breathWarmupMinutes: breathWarmupStatus === 'complete' ? breathWarmupMinutes : 0,
             exercisesCompleted: completedExercises,
             nearSnellenResult: nearSnellenResult || null,
             farSnellenResult: farSnellenResult || null,
@@ -400,7 +467,67 @@ export default function DailyPractice() {
           visionType="near"
           exerciseType="letters"
           initialLevel={1}
+          nightMode={nightMode}
         />
+      </div>
+    )
+  }
+
+  const plannedWarmupMinutes = breathWarmupEnabled ? breathWarmupMinutes : 0
+  const plannedTotalMinutes = session.totalMinutes + plannedWarmupMinutes
+  const warmupExercise = {
+    name: `${breathWarmupMinutes}-Minute Vision Warm-Up`,
+    inhaleMs: 4000,
+    exhaleMs: 6000,
+    inhaleHoldMs: 0,
+    exhaleHoldMs: 0,
+    breathsPerCycle: breathWarmupMinutes * 6,
+    cyclesTarget: 1,
+    backgroundMusic: null,
+    musicVolume: 0
+  }
+  const warmChromeClass = nightMode
+    ? 'bg-gradient-to-br from-[#17100a]/90 to-[#0c0906]/90 backdrop-blur-sm border border-amber-900/40'
+    : 'bg-gradient-to-br from-gray-800/80 to-gray-900/80 backdrop-blur-sm border border-primary-400/20'
+  const warmSubtleTextClass = nightMode ? 'text-amber-100/70' : 'text-gray-400'
+
+  if (showBreathWarmup) {
+    return (
+      <div className="space-y-6">
+        <button
+          onClick={skipBreathWarmup}
+          className="text-primary-400 hover:text-primary-300 flex items-center gap-2"
+        >
+          <ChevronRight className="w-4 h-4 rotate-180" />
+          Skip warm-up
+        </button>
+
+        <div className={`${warmChromeClass} rounded-xl p-6 shadow-lg`}>
+          <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-5">
+            <div>
+              <h3 className="text-xl font-bold text-white flex items-center gap-2">
+                <Wind className="w-5 h-5 text-primary-400" />
+                Breathing Warm-Up
+              </h3>
+              <p className={`${warmSubtleTextClass} text-sm mt-1`}>
+                {breathWarmupMinutes} minute{breathWarmupMinutes === 1 ? '' : 's'} before today's vision work
+              </p>
+            </div>
+            <button
+              onClick={skipBreathWarmup}
+              className="px-4 py-2 rounded-lg bg-gray-700/70 hover:bg-gray-600 text-gray-200 text-sm font-semibold transition-colors"
+            >
+              Skip warm-up
+            </button>
+          </div>
+
+          <MiniBreathExercise
+            compact
+            showCloseButton={false}
+            exercise={warmupExercise}
+            onClose={completeBreathWarmup}
+          />
+        </div>
       </div>
     )
   }
@@ -428,7 +555,7 @@ export default function DailyPractice() {
             <div className="text-right">
               <div className="flex items-center gap-1 text-gray-400">
                 <Clock className="w-4 h-4" />
-                <span className="text-sm">{session.totalMinutes} min</span>
+                <span className="text-sm">{plannedTotalMinutes} min</span>
               </div>
             </div>
           </div>
@@ -498,6 +625,56 @@ export default function DailyPractice() {
                 </div>
               </div>
 
+              {/* Breath warm-up preference */}
+              <div className={`${warmChromeClass} rounded-xl p-4`}>
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex items-center gap-3">
+                    <div className="p-2 bg-primary-500/20 rounded-lg">
+                      <Wind className="w-5 h-5 text-primary-400" />
+                    </div>
+                    <div>
+                      <div className="text-white font-semibold">Breathing Warm-Up</div>
+                      <div className={`${warmSubtleTextClass} text-sm`}>
+                        {breathWarmupEnabled ? `${breathWarmupMinutes} minute${breathWarmupMinutes === 1 ? '' : 's'}` : 'Skipped by default'}
+                      </div>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    aria-pressed={breathWarmupEnabled}
+                    onClick={() => updateBreathWarmupEnabled(!breathWarmupEnabled)}
+                    className={`relative h-7 w-12 rounded-full transition-colors ${
+                      breathWarmupEnabled ? 'bg-secondary-500' : 'bg-gray-600'
+                    }`}
+                  >
+                    <span
+                      className={`absolute top-1 h-5 w-5 rounded-full bg-white shadow transition-all ${
+                        breathWarmupEnabled ? 'left-6' : 'left-1'
+                      }`}
+                    />
+                  </button>
+                </div>
+
+                {breathWarmupEnabled && (
+                  <div className="grid grid-cols-3 gap-2 mt-4">
+                    {[1, 2, 3].map(minutes => (
+                      <button
+                        key={minutes}
+                        type="button"
+                        onClick={() => updateBreathWarmupMinutes(minutes)}
+                        className={`py-2 rounded-lg text-sm font-semibold transition-all ${
+                          breathWarmupMinutes === minutes
+                            ? 'bg-primary-600 text-white shadow-md shadow-primary-500/20'
+                            : 'bg-gray-700/50 text-gray-300 hover:bg-gray-600/50'
+                        }`}
+                      >
+                        {minutes} min
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+
               {/* Coaching cues */}
               <div className="bg-yellow-500/10 backdrop-blur-sm border border-yellow-500/30 rounded-xl p-4">
                 <h4 className="text-yellow-300 font-semibold mb-2 flex items-center gap-2">
@@ -513,7 +690,7 @@ export default function DailyPractice() {
 
               {/* Start button */}
               <button
-                onClick={() => setSessionStarted(true)}
+                onClick={startSessionWithOptionalWarmup}
                 className="w-full py-4 bg-gradient-to-r from-primary-500 to-secondary-500 hover:from-primary-600 hover:to-secondary-600 text-white font-bold text-lg rounded-xl transition-all flex items-center justify-center gap-2"
               >
                 <Play className="w-5 h-5" />

--- a/src/components/Vision/Training/TrainingSession.tsx
+++ b/src/components/Vision/Training/TrainingSession.tsx
@@ -14,6 +14,7 @@ interface TrainingSessionProps {
   deviceMode?: 'phone' | 'desktop'
   binocularMode?: BinocularMode
   untimed?: boolean
+  nightMode?: boolean
   onActiveChange?: (isActive: boolean) => void
   onExit?: () => void
 }
@@ -49,6 +50,7 @@ export default function TrainingSession({
   deviceMode = 'phone',
   binocularMode = 'off',
   untimed = false,
+  nightMode = false,
   onActiveChange,
   onExit
 }: TrainingSessionProps) {
@@ -73,6 +75,17 @@ export default function TrainingSession({
   const difficulty = DIFFICULTY_LEVELS[currentLevel - 1] || DIFFICULTY_LEVELS[0]
   const accuracy = attempts > 0 ? (correct / attempts) * 100 : 0
   const currentGlassesStage = READER_GLASSES_STAGES[readerGlassesStage] || READER_GLASSES_STAGES[0]
+  const chartShellClass = nightMode
+    ? 'relative rounded-xl overflow-hidden bg-[#050403] ring-1 ring-amber-900/40'
+    : 'relative'
+  const statsBarClass = nightMode
+    ? 'bg-[#0d0905]/95 backdrop-blur-sm border-b border-amber-900/40 px-4 py-2 flex items-center justify-between'
+    : 'bg-gray-900/80 backdrop-blur-sm px-4 py-2 flex items-center justify-between'
+  const inactivePanelClass = nightMode
+    ? 'bg-[#100b07]/80 border border-amber-900/40 rounded-lg p-6 shadow-inner'
+    : 'bg-gray-900/40 border border-primary-400/30 rounded-lg p-6 shadow-inner'
+  const statTileClass = nightMode ? 'bg-[#17100a]/80' : 'bg-gray-800/50'
+  const mutedTextClass = nightMode ? 'text-amber-100/60' : 'text-gray-400'
 
   // Reset target distance if device mode changes
   useEffect(() => {
@@ -250,9 +263,9 @@ export default function TrainingSession({
     <div className="space-y-4">
       {/* CHART FIRST when active - this is the main focus! */}
       {isActive && !sessionComplete && (
-        <div className="relative">
+        <div className={chartShellClass}>
           {/* Unified stats bar — matches mockup: stats left, controls right */}
-          <div className="bg-gray-900/80 backdrop-blur-sm px-4 py-2 flex items-center justify-between">
+          <div className={statsBarClass}>
             <div className="flex items-center gap-4 text-sm">
               <span className="text-white font-semibold">{difficulty.label}</span>
               <span className="text-gray-600">|</span>
@@ -333,13 +346,13 @@ export default function TrainingSession({
 
       {/* Header with stats - show when NOT active */}
       {!isActive && (
-        <div className="bg-gray-900/40 border border-primary-400/30 rounded-lg p-6 shadow-inner">
+        <div className={inactivePanelClass}>
         <div className="flex flex-wrap items-center justify-between gap-4 mb-4">
           <div>
             <h3 className="text-2xl font-bold text-white mb-1">
               Level {currentLevel} - {difficulty.label}
             </h3>
-            <p className="text-gray-400 text-sm">
+            <p className={`${mutedTextClass} text-sm`}>
               {visionType === 'near' ? 'Near Vision' : 'Far Vision'} Training
             </p>
           </div>
@@ -376,22 +389,22 @@ export default function TrainingSession({
 
         {/* Session stats */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-gray-800/50 rounded-lg p-3">
-            <p className="text-gray-400 text-xs mb-1">Time</p>
+          <div className={`${statTileClass} rounded-lg p-3`}>
+            <p className={`${mutedTextClass} text-xs mb-1`}>Time</p>
             <p className="text-white text-xl font-bold">{formatTime(sessionDuration)}</p>
           </div>
-          <div className="bg-gray-800/50 rounded-lg p-3">
-            <p className="text-gray-400 text-xs mb-1">Accuracy</p>
+          <div className={`${statTileClass} rounded-lg p-3`}>
+            <p className={`${mutedTextClass} text-xs mb-1`}>Accuracy</p>
             <p className={`text-xl font-bold ${accuracy >= difficulty.requiredAccuracy ? 'text-secondary-400' : 'text-yellow-400'}`}>
               {accuracy.toFixed(0)}%
             </p>
           </div>
-          <div className="bg-gray-800/50 rounded-lg p-3">
-            <p className="text-gray-400 text-xs mb-1">Attempts</p>
+          <div className={`${statTileClass} rounded-lg p-3`}>
+            <p className={`${mutedTextClass} text-xs mb-1`}>Attempts</p>
             <p className="text-white text-xl font-bold">{attempts}/10</p>
           </div>
-          <div className="bg-gray-800/50 rounded-lg p-3">
-            <p className="text-gray-400 text-xs mb-1">Required</p>
+          <div className={`${statTileClass} rounded-lg p-3`}>
+            <p className={`${mutedTextClass} text-xs mb-1`}>Required</p>
             <p className="text-primary-400 text-xl font-bold">{difficulty.requiredAccuracy}%</p>
           </div>
         </div>
@@ -400,7 +413,11 @@ export default function TrainingSession({
 
       {/* Distance Progression Panel - for near vision training - hide when active */}
       {!isActive && visionType === 'near' && distanceProgressionMode && (
-        <div className="bg-gradient-to-r from-blue-600/20 to-cyan-600/20 border border-blue-400/30 rounded-lg p-5">
+        <div className={`border rounded-lg p-5 ${
+          nightMode
+            ? 'bg-gradient-to-r from-[#17100a]/85 to-[#0d0905]/85 border-amber-900/40'
+            : 'bg-gradient-to-r from-blue-600/20 to-cyan-600/20 border-blue-400/30'
+        }`}>
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-3">
               <div className="p-2 bg-blue-500/20 rounded-lg">
@@ -523,7 +540,9 @@ export default function TrainingSession({
 
       {/* Instructions for first-time users */}
       {!isActive && !sessionComplete && attempts === 0 && (
-        <div className="bg-blue-500/10 border border-blue-400/30 rounded-lg p-6">
+        <div className={`border rounded-lg p-6 ${
+          nightMode ? 'bg-amber-950/20 border-amber-900/40' : 'bg-blue-500/10 border-blue-400/30'
+        }`}>
           <h4 className="text-blue-300 font-semibold mb-3">How to Train:</h4>
           <ul className="text-gray-300 space-y-2 text-sm">
             <li>• Press Start to begin your training session</li>

--- a/src/components/Vision/VisionTraining.tsx
+++ b/src/components/Vision/VisionTraining.tsx
@@ -10,7 +10,9 @@ import {
   Award,
   Smartphone,
   Monitor,
-  RotateCcw
+  RotateCcw,
+  Moon,
+  Sun
 } from 'lucide-react'
 import { PortalHeader } from '@/components/Navigation/PortalHeader'
 import CurriculumOverview from './Training/CurriculumOverview'
@@ -19,6 +21,7 @@ import QuickPractice from './Training/QuickPractice'
 import TrainingSession from './Training/TrainingSession'
 
 type TabMode = 'today' | 'trainer' | 'exercises'
+const NIGHT_MODE_KEY = 'visionTraining.nightMode'
 
 interface EnrollmentData {
   currentWeek: number
@@ -56,6 +59,7 @@ export function VisionTraining() {
   const [loading, setLoading] = useState(true)
   const [enrollmentData, setEnrollmentData] = useState<EnrollmentData | null>(null)
   const [todaySession, setTodaySession] = useState<TodaySessionData | null>(null)
+  const [nightMode, setNightMode] = useState(false)
 
   // Trainer settings
   const [trainerVisionType, setTrainerVisionType] = useState<'near' | 'far'>('near')
@@ -64,6 +68,11 @@ export function VisionTraining() {
   const [binocularMode, setBinocularMode] = useState<'off' | 'duplicate' | 'redgreen' | 'grid-square' | 'grid-slanted' | 'alternating'>('off')
   const [untimedMode, setUntimedMode] = useState(false)
   const [isTrainingActive, setIsTrainingActive] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    setNightMode(window.localStorage.getItem(NIGHT_MODE_KEY) === 'true')
+  }, [])
 
   // Dispatch binocular training mode events for hiding UI elements
   useEffect(() => {
@@ -133,11 +142,28 @@ export function VisionTraining() {
     }
   }
 
+  const toggleNightMode = () => {
+    setNightMode(current => {
+      const next = !current
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(NIGHT_MODE_KEY, String(next))
+      }
+      return next
+    })
+  }
+
+  const pageShellClass = nightMode
+    ? 'min-h-screen bg-[#070604]'
+    : 'min-h-screen bg-gradient-to-br from-gray-900 to-gray-800'
+  const pageBackgroundImage = nightMode
+    ? 'linear-gradient(rgba(8, 6, 3, 0.88), rgba(5, 4, 2, 0.94)), url(/hero-background.jpg)'
+    : 'linear-gradient(rgba(0,0,0,0.7), rgba(0,0,0,0.8)), url(/hero-background.jpg)'
+
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-gray-900 to-gray-800"
+      <div className={pageShellClass}
         style={{
-          backgroundImage: 'linear-gradient(rgba(0,0,0,0.7), rgba(0,0,0,0.8)), url(/hero-background.jpg)',
+          backgroundImage: pageBackgroundImage,
           backgroundSize: 'cover',
           backgroundPosition: 'center',
           backgroundAttachment: 'fixed'
@@ -169,9 +195,11 @@ export function VisionTraining() {
   ]
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 to-gray-800"
+    <div
+      className={pageShellClass}
+      data-vision-night-mode={nightMode ? 'true' : 'false'}
       style={{
-        backgroundImage: 'linear-gradient(rgba(0,0,0,0.7), rgba(0,0,0,0.8)), url(/hero-background.jpg)',
+        backgroundImage: pageBackgroundImage,
         backgroundSize: 'cover',
         backgroundPosition: 'center',
         backgroundAttachment: 'fixed'
@@ -192,7 +220,7 @@ export function VisionTraining() {
         </div>
 
         {/* Tab Navigation - 3 tabs only */}
-        <div className="flex justify-center gap-2 md:gap-4 mb-3 md:mb-6 px-4">
+        <div className="flex flex-wrap justify-center gap-2 md:gap-4 mb-3 md:mb-6 px-4">
           {tabs.map(tab => {
             const Icon = tab.icon
             const isActive = activeTab === tab.id
@@ -210,6 +238,19 @@ export function VisionTraining() {
               </button>
             )
           })}
+          <button
+            type="button"
+            onClick={toggleNightMode}
+            aria-pressed={nightMode}
+            className={`px-4 md:px-5 py-3 rounded-lg font-semibold transition-all duration-300 flex items-center gap-2 ${
+              nightMode
+                ? 'bg-amber-500/20 text-amber-100 border border-amber-500/40'
+                : 'bg-gray-800/30 backdrop-blur-sm text-gray-300 hover:bg-gray-700/30'
+            }`}
+          >
+            {nightMode ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+            <span className="hidden sm:inline">{nightMode ? 'Day Mode' : 'Night Mode'}</span>
+          </button>
         </div>
 
         {/* Tab Content */}
@@ -222,7 +263,11 @@ export function VisionTraining() {
                 {isEnrolled && enrollmentData && todaySession ? (
                   <>
                     {/* Compact Progress Bar */}
-                    <div className="bg-gradient-to-br from-gray-800/60 to-gray-900/60 backdrop-blur-sm rounded-xl p-4 border border-primary-400/20">
+                    <div className={`backdrop-blur-sm rounded-xl p-4 border ${
+                      nightMode
+                        ? 'bg-gradient-to-br from-[#17100a]/85 to-[#0c0906]/85 border-amber-900/40'
+                        : 'bg-gradient-to-br from-gray-800/60 to-gray-900/60 border-primary-400/20'
+                    }`}>
                       <div className="flex items-center justify-between mb-2">
                         <div className="flex items-center gap-3">
                           <span className="text-white font-semibold">
@@ -256,7 +301,7 @@ export function VisionTraining() {
                     </div>
 
                     {/* Daily Practice Component (has session content + progress summary) */}
-                    <DailyPractice />
+                    <DailyPractice nightMode={nightMode} />
                   </>
                 ) : (
                   /* Not Enrolled - Show Curriculum Overview with enrollment */
@@ -270,7 +315,11 @@ export function VisionTraining() {
               <div className="space-y-4">
                 {/* Settings card - ONLY show when NOT training */}
                 {!isTrainingActive && (
-                  <div className="bg-gradient-to-br from-gray-800/80 to-gray-900/80 backdrop-blur-sm rounded-xl p-4 sm:p-6 border border-primary-400/20 shadow-lg">
+                  <div className={`backdrop-blur-sm rounded-xl p-4 sm:p-6 border shadow-lg ${
+                    nightMode
+                      ? 'bg-gradient-to-br from-[#17100a]/90 to-[#0c0906]/90 border-amber-900/40'
+                      : 'bg-gradient-to-br from-gray-800/80 to-gray-900/80 border-primary-400/20'
+                  }`}>
                     {/* Header with inline Start Training */}
                     <div className="flex items-start justify-between gap-3 mb-3">
                       <div>
@@ -443,7 +492,7 @@ export function VisionTraining() {
                 {isTrainingActive && binocularMode !== 'off' ? (
                   typeof window !== 'undefined' ? createPortal(
                     /* Fullscreen overlay for binocular — hides navbars and microphone */
-                    <div className="fixed inset-0 w-full h-full z-[99999] bg-gray-900 flex flex-col overflow-hidden">
+                    <div className={`fixed inset-0 w-full h-full z-[99999] flex flex-col overflow-hidden ${nightMode ? 'bg-[#050403]' : 'bg-gray-900'}`}>
                       <div className="flex-1 flex flex-col">
                         <TrainingSession
                           visionType={trainerVisionType}
@@ -451,6 +500,7 @@ export function VisionTraining() {
                           deviceMode={trainerDeviceMode}
                           binocularMode={binocularMode}
                           untimed={untimedMode}
+                          nightMode={nightMode}
                           onExit={() => setIsTrainingActive(false)}
                           onActiveChange={(active) => {
                             if (!active) setIsTrainingActive(false)
@@ -464,7 +514,7 @@ export function VisionTraining() {
                   <div className="space-y-4">
                     <button
                       onClick={() => setIsTrainingActive(false)}
-                      className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
+                      className={`flex items-center gap-2 transition-colors ${nightMode ? 'text-amber-100/60 hover:text-amber-100' : 'text-gray-400 hover:text-white'}`}
                     >
                       <RotateCcw className="w-4 h-4" />
                       Back to Settings
@@ -475,6 +525,7 @@ export function VisionTraining() {
                       deviceMode={trainerDeviceMode}
                       binocularMode={binocularMode}
                       untimed={untimedMode}
+                      nightMode={nightMode}
                       onActiveChange={(active) => {
                         if (!active) setIsTrainingActive(false)
                       }}


### PR DESCRIPTION
Work item: jonchyatt/codex-worklist#13

## Summary
- add an optional 1-3 minute breathing warm-up before daily vision sessions using the existing MiniBreathExercise component
- persist warm-up preferences and night mode in localStorage
- store completed warm-up minutes on VisionDailySession and include them in session/practice totals
- add night-mode chrome around vision training surfaces while leaving Snellen, red/green binocular, and Gabor stimuli unfiltered

## Verification
- npx prisma validate
- npx prisma generate
- npx tsc --noEmit
- npm run build
- Browser smoke test on http://localhost:3101/vision-training
  - night mode toggles and persists after reload
  - Snellen chart stays white with filter none
  - Red/Green binocular fullscreen overlay dims chrome; red/green/white stimulus descendants have no filter or blend mode
  - Gabor canvas stays neutral gray with filter none